### PR TITLE
[#11] GlobalExceptionHandler 구현

### DIFF
--- a/src/main/java/com/project/Karman/config/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/project/Karman/config/security/handler/JwtAccessDeniedHandler.java
@@ -24,12 +24,11 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
         String jsonResponse = """
                 {
-                    "error": "FORBIDDEN",
-                    "message": "접근 권한이 없습니다.",
-                    "timestamp": "%s",
+                    "message": "%s",
+                    "code": "%s",
                     "path": "%s"
                 }
-                """.formatted(LocalDateTime.now(), request.getRequestURI());
+                """.formatted("접근 권한이 없습니다.",response.getStatus(), request.getRequestURI());
 
         response.getWriter().write(jsonResponse);
     }

--- a/src/main/java/com/project/Karman/config/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/Karman/config/security/handler/JwtAuthenticationEntryPoint.java
@@ -22,12 +22,11 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         String jsonResponse = """
                 {
-                    "error": "UNAUTHORIZED",
-                    "message": "인증이 필요합니다. 로그인 후 다시 시도해주세요.",
-                    "timestamp": "%s",
+                    "message": "%s",
+                    "code": "%s",
                     "path": "%s"
                 }
-                """.formatted(LocalDateTime.now(), request.getRequestURI());
+                """.formatted("인증이 필요합니다. 로그인 후 다시 시도해주세요.", response.getStatus(), request.getRequestURI());
 
         response.getWriter().write(jsonResponse);
     }

--- a/src/main/java/com/project/Karman/controller/AuthController.java
+++ b/src/main/java/com/project/Karman/controller/AuthController.java
@@ -2,15 +2,18 @@ package com.project.Karman.controller;
 
 import com.project.Karman.dto.request.LoginRequestDto;
 import com.project.Karman.dto.request.SignupRequestDto;
+import com.project.Karman.dto.response.ApiResponse;
 import com.project.Karman.dto.response.JwtTokenDto;
 import com.project.Karman.service.AuthService;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.project.Karman.exception.SuccessMessage.LOGIN;
+import static com.project.Karman.exception.SuccessMessage.SIGNUP;
 
 @RestController
 @RequestMapping("/auth")
@@ -24,15 +27,15 @@ public class AuthController {
 
     // 회원 가입
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
         authService.signup(signupRequestDto);
-        return new ResponseEntity<>("회원 가입 완료", HttpStatus.OK);
+        return ResponseEntity.status(SIGNUP.getHttpStatus()).body(ApiResponse.success(SIGNUP.getMessage()));
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<JwtTokenDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+    public ResponseEntity<ApiResponse<JwtTokenDto>> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
         JwtTokenDto token = authService.login(loginRequestDto);
-        return new ResponseEntity<>(token, HttpStatus.OK);
+        return ResponseEntity.status(LOGIN.getHttpStatus()).body(ApiResponse.success(LOGIN.getMessage(), token));
     }
 }

--- a/src/main/java/com/project/Karman/controller/ClubController.java
+++ b/src/main/java/com/project/Karman/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.project.Karman.config.security.CustomUserDetails;
 import com.project.Karman.dto.request.ClubCreateRequestDto;
 import com.project.Karman.dto.request.ClubUpdateRequestDto;
 import com.project.Karman.dto.request.JoinStatusUpdateRequestDto;
+import com.project.Karman.dto.response.ApiResponse;
 import com.project.Karman.dto.response.ClubInfoResponseDto;
 import com.project.Karman.dto.response.PlayersInfoResponse;
 import com.project.Karman.dto.response.SearchClubResponseDto;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+import static com.project.Karman.exception.SuccessMessage.*;
+
 @RestController
 @RequestMapping("/clubs")
 public class ClubController {
@@ -27,68 +30,86 @@ public class ClubController {
         this.clubService = clubService;
     }
 
-    @GetMapping("/{club_id}/player-list")
-    public ResponseEntity<List<PlayersInfoResponse>> getPlayersByClub(@PathVariable(value = "club_id") UUID clubId) {
-        List<PlayersInfoResponse> playersInfo = clubService.findPlayersInfoByClub(clubId);
-        return new ResponseEntity<>(playersInfo, HttpStatus.OK);
-    }
 
     @PostMapping
-    public ResponseEntity<String> createClub(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                             @Valid @RequestBody ClubCreateRequestDto request) {
+    public ResponseEntity<ApiResponse<Void>> createClub(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                        @Valid @RequestBody ClubCreateRequestDto request) {
         clubService.createClub(userDetails.getmember(), request);
-        return new ResponseEntity<>("클럽 생성 완료", HttpStatus.OK);
-    }
-
-    @PatchMapping("/{club_id}")
-    public ResponseEntity<String> modifyClub(@PathVariable(value = "club_id") UUID clubId,
-                                             @AuthenticationPrincipal CustomUserDetails userDetails,
-                                             @Valid @RequestBody ClubUpdateRequestDto request) {
-        clubService.modifyClubInfo(clubId, userDetails.getmember(), request);
-        return new ResponseEntity<>("클럽 수정 완료", HttpStatus.OK);
-    }
-
-    @DeleteMapping("/{club_id}")
-    public ResponseEntity<String> deleteClub(@PathVariable(value = "club_id") UUID clubId,
-                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        clubService.deleteClub(clubId, userDetails.getmember());
-        return new ResponseEntity<>("클럽 삭제 완료", HttpStatus.OK);
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<List<SearchClubResponseDto>> searchClub(@RequestParam(name = "clubName") String param) {
-        List<SearchClubResponseDto> searchClubDtoList = clubService.searchClub(param);
-        return new ResponseEntity<>(searchClubDtoList, HttpStatus.OK);
+        return ResponseEntity
+                .status(CREATE_CLUB.getHttpStatus())
+                .body(ApiResponse.success(CREATE_CLUB.getMessage()));
     }
 
     @GetMapping("/{club_id}")
-    public ResponseEntity<ClubInfoResponseDto> getClubInfo(@PathVariable(value = "club_id") UUID clubId,
-                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<ClubInfoResponseDto>> getClubInfo(@PathVariable(value = "club_id") UUID clubId,
+                                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
         ClubInfoResponseDto clubInfoDto = clubService.getClubInfo(clubId, userDetails.getmember());
-        return new ResponseEntity<>(clubInfoDto, HttpStatus.OK);
+        return ResponseEntity
+                .status(GET_CLUB_INFO.getHttpStatus())
+                .body(ApiResponse.success(GET_CLUB_INFO.getMessage(), clubInfoDto));
+    }
+
+    @PatchMapping("/{club_id}")
+    public ResponseEntity<ApiResponse<Void>> modifyClub(@PathVariable(value = "club_id") UUID clubId,
+                                                        @AuthenticationPrincipal CustomUserDetails userDetails,
+                                                        @Valid @RequestBody ClubUpdateRequestDto request) {
+        clubService.modifyClubInfo(clubId, userDetails.getmember(), request);
+        return ResponseEntity
+                .status(UPDATE_CLUB.getHttpStatus())
+                .body(ApiResponse.success(UPDATE_CLUB.getMessage()));
+    }
+
+    @DeleteMapping("/{club_id}")
+    public ResponseEntity<ApiResponse<Void>> deleteClub(@PathVariable(value = "club_id") UUID clubId,
+                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        clubService.deleteClub(clubId, userDetails.getmember());
+        return ResponseEntity
+                .status(DELETE_CLUB.getHttpStatus())
+                .body(ApiResponse.success(DELETE_CLUB.getMessage()));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<SearchClubResponseDto>>> searchClub(@RequestParam(name = "clubName") String param) {
+        List<SearchClubResponseDto> searchClubDtoList = clubService.searchClub(param);
+        return ResponseEntity
+                .status(SEARCH_CLUB.getHttpStatus())
+                .body(ApiResponse.success(SEARCH_CLUB.getMessage(), searchClubDtoList));
+    }
+
+    @GetMapping("/{club_id}/player-list")
+    public ResponseEntity<ApiResponse<List<PlayersInfoResponse>>> getPlayersByClub(@PathVariable(value = "club_id") UUID clubId) {
+        List<PlayersInfoResponse> playersInfo = clubService.findPlayersInfoByClub(clubId);
+        return ResponseEntity
+                .status(GET_PLAYERS_IN_CLUB.getHttpStatus())
+                .body(ApiResponse.success(GET_PLAYERS_IN_CLUB.getMessage(), playersInfo));
     }
 
     @PostMapping("/{club_id}/join")
-    public ResponseEntity<String> joinClub(@PathVariable(value = "club_id") UUID clubId,
-                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<Void>> requestJoinClub(@PathVariable(value = "club_id") UUID clubId,
+                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
         clubService.requestJoinClub(clubId, userDetails.getmember());
-        return new ResponseEntity<>("가입 신청 완료", HttpStatus.OK);
+        return ResponseEntity
+                .status(REQUEST_JOIN_CLUB.getHttpStatus())
+                .body(ApiResponse.success(REQUEST_JOIN_CLUB.getMessage()));
     }
 
     @PatchMapping("/{club_id}/players/{player_id}/update")
-    public ResponseEntity<String> updateClubJoinStatus(@PathVariable(value = "club_id") UUID clubId,
-                                                       @PathVariable(value = "player_id") UUID playerId,
-                                                       @RequestBody JoinStatusUpdateRequestDto request,
-                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
-
+    public ResponseEntity<ApiResponse<Void>> updateClubJoinStatus(@PathVariable(value = "club_id") UUID clubId,
+                                                                  @PathVariable(value = "player_id") UUID playerId,
+                                                                  @RequestBody JoinStatusUpdateRequestDto request,
+                                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
         String message = clubService.updateClubJoinStatus(clubId, playerId, request, userDetails.getmember());
-        return new ResponseEntity<>(message, HttpStatus.OK);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(message));
     }
 
     @DeleteMapping("/{club_id}/withdraw")
-    public ResponseEntity<String> withdrawClub(@PathVariable(value = "club_id") UUID clubId,
-                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<Void>> withdrawClub(@PathVariable(value = "club_id") UUID clubId,
+                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
         clubService.withdrawClub(clubId, userDetails.getmember());
-        return new ResponseEntity<>("클럽 탈퇴 완료", HttpStatus.OK);
+        return ResponseEntity
+                .status(WITHDRAW_CLUB.getHttpStatus())
+                .body(ApiResponse.success(WITHDRAW_CLUB.getMessage()));
     }
 }

--- a/src/main/java/com/project/Karman/dto/response/ApiResponse.java
+++ b/src/main/java/com/project/Karman/dto/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.project.Karman.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+
+public record ApiResponse<T>(
+        @NotNull String message,
+        @NotNull int code,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data) {
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(message, 200, data);
+    }
+
+    public static ApiResponse<Void> success(String message) {
+        return new ApiResponse<>(message, 200, null);
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/ErrorResponse.java
+++ b/src/main/java/com/project/Karman/dto/response/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.project.Karman.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.project.Karman.exception.CustomException;
+import jakarta.validation.constraints.NotNull;
+
+public record ErrorResponse<T>(
+        @NotNull String message,
+        @NotNull int code,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data) {
+
+    public static ErrorResponse<Object> error(CustomException e) {
+        return new ErrorResponse<>(e.getMessage(), e.getCode(), null);
+    }
+
+    public static ErrorResponse<Void> error(String message, int code) {
+        return new ErrorResponse<>(message, code, null);
+    }
+}

--- a/src/main/java/com/project/Karman/exception/CustomException.java
+++ b/src/main/java/com/project/Karman/exception/CustomException.java
@@ -1,0 +1,24 @@
+package com.project.Karman.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    public CustomException(HttpStatus httpStatus, String message, int code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+
+    public CustomException(ExceptionMessage exceptionMessage) {
+        this.httpStatus = exceptionMessage.getHttpStatus();
+        this.message = exceptionMessage.getMessage();
+        this.code = exceptionMessage.getCode();
+    }
+}

--- a/src/main/java/com/project/Karman/exception/ExceptionMessage.java
+++ b/src/main/java/com/project/Karman/exception/ExceptionMessage.java
@@ -1,0 +1,32 @@
+package com.project.Karman.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ExceptionMessage {
+    SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러가 발생했습니다.", 500),
+
+    // Member
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.", 400),
+    PERMISSION_DENIED_MEMBER(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다.", 403),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "찾을 수 없는 유저정보 입니다.", 404),
+    DUPLICATED_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다.", 409),
+    // Club
+    OWNER_CAN_NOT_WITHDRAW_CLUB(HttpStatus.BAD_REQUEST, "구단주는 클럽을 탈퇴할 수 없습니다.",400), // 탈퇴하면 클럽 삭제 되도록 수정
+    ALREADY_JOINED_PLAYER(HttpStatus.BAD_REQUEST,"이미 가입된 선수입니다.", 400),
+    NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "찾을 수 없는 클럽(팀) 입니다.", 404),
+    NOT_FOUND_PLAYER_IN_CLUB(HttpStatus.NOT_FOUND, "클럽(팀)에 소속되지 않은 선수 입니다.", 404),
+
+    // Match
+    NOT_FOUND_MATCH(HttpStatus.NOT_FOUND, "찾을 수 없는 매치정보 입니다.", 404);
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    ExceptionMessage(HttpStatus httpStatus, String message, int code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/project/Karman/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/Karman/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.project.Karman.exception;
+
+import com.project.Karman.dto.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.project.Karman.exception.ExceptionMessage.SYSTEM_ERROR;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+
+        return ResponseEntity.status(e.getHttpStatus()).body(ErrorResponse.error(e));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+
+        // 미확인 내부서버 에러 위치 및 내용 확인
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ErrorResponse.error(SYSTEM_ERROR.getMessage(),
+                SYSTEM_ERROR.getCode()));
+    }
+}

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -10,13 +10,16 @@ public enum SuccessMessage {
     LOGIN(HttpStatus.OK, "로그인 성공", 200),
 
     // 클럽 서비스
-    CREATE_CLUB(HttpStatus.OK, "클럽 생성 성공", 200),
-    UPDATE_CLUB(HttpStatus.OK, "클럽 정보 수정 성공", 200),
+    CREATE_CLUB(HttpStatus.OK, "클럽 생성 완료", 200),
+    GET_CLUB_INFO(HttpStatus.OK, "클럽 상세 정보 조회", 200),
+    UPDATE_CLUB(HttpStatus.OK, "클럽 정보 수정 완료", 200),
     DELETE_CLUB(HttpStatus.OK, "클럽 삭제 완료", 200),
+    SEARCH_CLUB(HttpStatus.OK, "클럽 검색 완료", 200),
     REQUEST_JOIN_CLUB(HttpStatus.OK, "클럽 가입 신청 완료", 200),
     ACCEPT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 승인", 200),
     REJECT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 거부", 200),
-    WITHDRAW_CLUB(HttpStatus.OK, "클럽 탈퇴 완료.", 200);
+    WITHDRAW_CLUB(HttpStatus.OK, "클럽 탈퇴 완료.", 200),
+    GET_PLAYERS_IN_CLUB(HttpStatus.OK, "클럽 소속 선수들 정보 조회", 200);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -1,0 +1,30 @@
+package com.project.Karman.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessMessage {
+    // 회원가입, 로그인 성공
+    SIGNUP(HttpStatus.OK, "회원가입 완료", 200),
+    LOGIN(HttpStatus.OK, "로그인 성공", 200),
+
+    // 클럽 서비스
+    CREATE_CLUB(HttpStatus.OK, "클럽 생성 성공", 200),
+    UPDATE_CLUB(HttpStatus.OK, "클럽 정보 수정 성공", 200),
+    DELETE_CLUB(HttpStatus.OK, "클럽 삭제 완료", 200),
+    REQUEST_JOIN_CLUB(HttpStatus.OK, "클럽 가입 신청 완료", 200),
+    ACCEPT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 승인", 200),
+    REJECT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 거부", 200),
+    WITHDRAW_CLUB(HttpStatus.OK, "클럽 탈퇴 완료.", 200);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    SuccessMessage(HttpStatus httpStatus, String message, int code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/project/Karman/service/AuthService.java
+++ b/src/main/java/com/project/Karman/service/AuthService.java
@@ -5,14 +5,14 @@ import com.project.Karman.domain.entity.Member;
 import com.project.Karman.dto.request.LoginRequestDto;
 import com.project.Karman.dto.request.SignupRequestDto;
 import com.project.Karman.dto.response.JwtTokenDto;
+import com.project.Karman.exception.CustomException;
+import com.project.Karman.exception.ExceptionMessage;
 import com.project.Karman.repository.MemberRepository;
 import com.project.Karman.service.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -26,11 +26,11 @@ public class AuthService {
     public void signup(SignupRequestDto signupRequestDto) {
         // 이메일 중복 체크
         if (memberRepository.existsByEmail(signupRequestDto.email())) {
-            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+            throw new CustomException(ExceptionMessage.DUPLICATED_MEMBER_EMAIL);
         }
         // 패스워드 일치 체크
         if (!signupRequestDto.password().equals(signupRequestDto.passwordCheck())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new CustomException(ExceptionMessage.PASSWORD_MISMATCH);
         }
         // 비밀번호 인코딩
         String hashedPassword = passwordEncoder.encode(signupRequestDto.password());
@@ -44,11 +44,11 @@ public class AuthService {
     public JwtTokenDto login(LoginRequestDto loginRequestDto) {
         // 유저 찾기
         Member member = memberRepository.findByEmail(loginRequestDto.email())
-                .orElseThrow(() -> new NoSuchElementException("가입하지 않는 이메일입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
 
         // 비밀번호 일치확인
         if (!passwordEncoder.matches(loginRequestDto.password(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new CustomException(ExceptionMessage.PASSWORD_MISMATCH);
         }
 
         // 토큰 생성 및 반환

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -12,6 +12,8 @@ import com.project.Karman.dto.request.JoinStatusUpdateRequestDto;
 import com.project.Karman.dto.response.ClubInfoResponseDto;
 import com.project.Karman.dto.response.PlayersInfoResponse;
 import com.project.Karman.dto.response.SearchClubResponseDto;
+import com.project.Karman.exception.CustomException;
+import com.project.Karman.exception.ExceptionMessage;
 import com.project.Karman.repository.MemberRepository;
 import com.project.Karman.service.mapper.AffiliationMapper;
 import com.project.Karman.repository.AffiliationRepository;
@@ -32,22 +34,6 @@ public class ClubService {
     private final AffiliationMapper affiliationMapper;
     private final ClubMapper clubMapper;
 
-    @Transactional(readOnly = true)
-    public List<PlayersInfoResponse> findPlayersInfoByClub(UUID clubId) {
-        // 클럽 존재 여부 확인
-        Club club = findClub(clubId);
-        // 클럽에 속한 선수 목록 조회
-        List<Affiliation> affiliations = affiliationRepository.findAllByClub(club);
-        // entity -> dto
-        List<PlayersInfoResponse> playersInfo = new ArrayList<>();
-        for (Affiliation player : affiliations) {
-            PlayersInfoResponse info = affiliationMapper.toDto(player);
-            playersInfo.add(info);
-        }
-
-        return playersInfo;
-    }
-
 
     @Transactional
     public void createClub(Member member, ClubCreateRequestDto request) {
@@ -55,11 +41,20 @@ public class ClubService {
         Club club = clubMapper.toEntity(member.getMemberId(), request);
         // 유저 정보 영속성 컨텍스트
         Member user = memberRepository.findById(member.getMemberId())
-                .orElseThrow(() -> new NoSuchElementException("찾을 수 없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
         // 연관관계 객체생성
         Affiliation owner = affiliationMapper.toEntity(club, user, ClubPlayerRole.OWNER);
         club.addPlayer(owner);
         clubRepository.save(club);
+    }
+
+    @Transactional(readOnly = true)
+    public ClubInfoResponseDto getClubInfo(UUID clubId, Member member) {
+        // 클럽 상세조회
+        Club club = findClub(clubId);
+        // TODO - 클럽에 소속한 선수는 디테일 정보 열람가능하도록 수정
+
+        return clubMapper.toDto(club);
     }
 
     @Transactional
@@ -68,7 +63,7 @@ public class ClubService {
         Club club = findClub(clubId);
         // 구단주와 접근 유저 동일 여부 체크
         if (!club.getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("권한이 없는 유저입니다.");
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
 
         AgeGroup updatedAgeGroup = request.ageGroup() != null ? AgeGroup.fromDescription(request.ageGroup()) : null;
@@ -82,7 +77,7 @@ public class ClubService {
         Club club = findClub(clubId);
         // 구단주와 접근 유저 동일 여부 체크
         if (!club.getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("권한이 없는 유저입니다.");
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
         // 클럽 삭제.
         clubRepository.delete(club);
@@ -101,12 +96,19 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public ClubInfoResponseDto getClubInfo(UUID clubId, Member member) {
-        // 클럽 상세조회
+    public List<PlayersInfoResponse> findPlayersInfoByClub(UUID clubId) {
+        // 클럽 존재 여부 확인
         Club club = findClub(clubId);
-        // TODO - 클럽에 소속한 선수는 디테일 정보 열람가능하도록 수정
+        // 클럽에 속한 선수 목록 조회
+        List<Affiliation> affiliations = affiliationRepository.findAllByClub(club);
+        // entity -> dto
+        List<PlayersInfoResponse> playersInfo = new ArrayList<>();
+        for (Affiliation player : affiliations) {
+            PlayersInfoResponse info = affiliationMapper.toDto(player);
+            playersInfo.add(info);
+        }
 
-        return clubMapper.toDto(club);
+        return playersInfo;
     }
 
     @Transactional
@@ -116,11 +118,11 @@ public class ClubService {
         // 유저 조회
         Optional<Affiliation> player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId());
         if (player.isPresent()) {
-            throw new IllegalArgumentException("이미 가입된 선수 입니다.");
+            throw new CustomException(ExceptionMessage.ALREADY_JOINED_PLAYER);
         }
         // 연관관계 객체생성
         Member user = memberRepository.findById(member.getMemberId())
-                .orElseThrow(() -> new NoSuchElementException("찾을 수 없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
         // 가입 신청
         Affiliation requestJoinMember = affiliationMapper.toEntity(club, user, ClubPlayerRole.USER);
         club.addPlayer(requestJoinMember);
@@ -132,11 +134,11 @@ public class ClubService {
         Club club = findClub(clubId);
         // 로그인 유저 권한 체크
         if (!club.getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("구단주가 아닌 유저는 가입 처리를 진행할 수 없습니다.");
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
         // 가입 요청한 선수 정보
         Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, playerId)
-                .orElseThrow(() -> new NoSuchElementException("찾을 수 없는 선수입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
         // 가입 상태 수정
         player.updateJoinStatus(request.joinStatus());
         // 여부에 따라서 메시지 변경
@@ -148,20 +150,18 @@ public class ClubService {
         // 클럽 조회
         Club club = findClub(clubId);
         if (club.getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("구단주는 현재 클럽을 탈퇴할 수 없습니다.");
+            throw new CustomException(ExceptionMessage.OWNER_CAN_NOT_WITHDRAW_CLUB);
         }
         // 선수 조회
         Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId())
-                .orElseThrow(() -> new NoSuchElementException("찾을 수 없는 선수입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
         // 삭제
         affiliationRepository.delete(player);
     }
 
-    //
     private Club findClub(UUID clubId) {
         // 클럽 상세조회
         return clubRepository.findById(clubId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 클럽입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
     }
-
 }


### PR DESCRIPTION
### **전역 예외처리 구현**
* 서버 내부 에러 -> 401, 403에러가 가로채는 현상 해결
  * 인증허가 된 상태에서 클라이언트의 요청 API에서 임무 수행 중에 발생한 에러에 대해 서블릿 컨테이너가 /error 경로로 요청을 보냄
  * 하지만, 해당 경로는 요청이 허가되지않았음. -> 인증요청 에러가 발생하게 됨.

위 문제를 해결하면서 서비스의 편의성을 위해 전체 전역예외처리를 구현