### PR TITLE
[#12] Match 서비스 쿼터 등록 API 초기 구현

### DIFF
--- a/src/main/java/com/project/Karman/controller/MatchController.java
+++ b/src/main/java/com/project/Karman/controller/MatchController.java
@@ -2,6 +2,9 @@ package com.project.Karman.controller;
 
 import com.project.Karman.config.security.CustomUserDetails;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.response.ApiResponse;
+import com.project.Karman.dto.response.MatchListResponseDto;
+import com.project.Karman.exception.SuccessMessage;
 import com.project.Karman.service.MatchService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -28,4 +32,16 @@ public class MatchController {
         matchService.createMatch(request, clubId, userDetails.getmember());
         return new ResponseEntity<>("경기 등록 완료", HttpStatus.OK);
     }
+
+    // 매치 등록
+    // 매치 전체 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MatchListResponseDto>>> getMatchList(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                @PathVariable(value = "club_id") UUID clubId) {
+        List<MatchListResponseDto> matchAll = matchService.getMatchAll(userDetails.getmember(), clubId);
+        return ResponseEntity.status(SuccessMessage.GET_MATCH_ALL.getCode()).body(ApiResponse.success(SuccessMessage.GET_MATCH_ALL.getMessage(), matchAll));
+    }
+
+    // 매치 상세 조회
+
 }

--- a/src/main/java/com/project/Karman/controller/MatchController.java
+++ b/src/main/java/com/project/Karman/controller/MatchController.java
@@ -2,6 +2,7 @@ package com.project.Karman.controller;
 
 import com.project.Karman.config.security.CustomUserDetails;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.request.MatchQuarterCreateRequestDto;
 import com.project.Karman.dto.response.ApiResponse;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import com.project.Karman.exception.SuccessMessage;
@@ -28,18 +29,30 @@ public class MatchController {
     @PostMapping
     public ResponseEntity<String> createMatch(@AuthenticationPrincipal CustomUserDetails userDetails,
                                               @PathVariable(value = "club_id") UUID clubId,
-                                              @Valid @RequestBody MatchCreateRequestDto request) {
-        matchService.createMatch(request, clubId, userDetails.getmember());
+                                              @Valid @RequestBody MatchCreateRequestDto requestDto) {
+        matchService.createMatch(requestDto, clubId, userDetails.getmember());
         return new ResponseEntity<>("경기 등록 완료", HttpStatus.OK);
     }
 
-    // 매치 등록
+    @PostMapping("/{match_id}/quarters")
+    public ResponseEntity<ApiResponse<Void>> createMatchQuarter(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                @PathVariable(value = "club_id") UUID clubId,
+                                                                @PathVariable(value = "match_id") UUID matchId,
+                                                                @Valid @RequestBody MatchQuarterCreateRequestDto requestDto) {
+        matchService.createMatchQuarter(requestDto, clubId, matchId, userDetails.getmember());
+        return ResponseEntity
+                .status(SuccessMessage.CREATE_MATCH_QUARTER.getCode())
+                .body(ApiResponse.success(SuccessMessage.CREATE_MATCH_QUARTER.getMessage()));
+    }
+
     // 매치 전체 조회
     @GetMapping
     public ResponseEntity<ApiResponse<List<MatchListResponseDto>>> getMatchList(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                                 @PathVariable(value = "club_id") UUID clubId) {
         List<MatchListResponseDto> matchAll = matchService.getMatchAll(userDetails.getmember(), clubId);
-        return ResponseEntity.status(SuccessMessage.GET_MATCH_ALL.getCode()).body(ApiResponse.success(SuccessMessage.GET_MATCH_ALL.getMessage(), matchAll));
+        return ResponseEntity
+                .status(SuccessMessage.GET_MATCH_ALL.getCode())
+                .body(ApiResponse.success(SuccessMessage.GET_MATCH_ALL.getMessage(), matchAll));
     }
 
     // 매치 상세 조회

--- a/src/main/java/com/project/Karman/domain/entity/Club.java
+++ b/src/main/java/com/project/Karman/domain/entity/Club.java
@@ -42,6 +42,11 @@ public class Club extends BaseEntity {
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Affiliation> affiliationPlayers = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Match> matches = new ArrayList<>();
+
+
     // 엔터티 생성시 사용
     public static Club of(UUID memberId, String clubName, String area, AgeGroup ageGroup, Date foundationDate) {
 

--- a/src/main/java/com/project/Karman/domain/entity/Match.java
+++ b/src/main/java/com/project/Karman/domain/entity/Match.java
@@ -4,6 +4,7 @@ import com.project.Karman.domain.enums.Weather;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -26,27 +27,32 @@ public class Match extends BaseEntity {
     private String opponent;
 
     @Column(nullable = false)
-    private Integer score;
+    private Integer scoredGoal;
 
     @Column(nullable = false)
-    private Integer concededScore;
+    private Integer concededGoal;
 
     @Column(nullable = false, length = 50)
     private String location;
+
+    @Column(nullable = false)
+    private LocalDateTime matchDate;
 
     @Column(nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
     private Weather weather;
 
 
-    public static Match of(UUID clubId, String opponent, Integer score, Integer concededScore, String location, Weather weather) {
+    public static Match of(UUID clubId, String opponent, Integer scoredGoal, Integer concededGoal,
+                           String location, LocalDateTime matchDate, Weather weather) {
 
         return Match.builder()
                 .clubId(clubId)
                 .opponent(opponent)
-                .score(score)
-                .concededScore(concededScore)
+                .scoredGoal(scoredGoal)
+                .concededGoal(concededGoal)
                 .location(location)
+                .matchDate(matchDate)
                 .weather(weather)
                 .build();
     }

--- a/src/main/java/com/project/Karman/domain/entity/Match.java
+++ b/src/main/java/com/project/Karman/domain/entity/Match.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -47,6 +49,10 @@ public class Match extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Weather weather = Weather.SUNNY;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MatchQuarter> matchQuarters = new ArrayList<>();
+
 
     public static Match of(Club club, String opponent, Integer scoredGoal, Integer concededGoal,
                            String location, LocalDateTime matchDate, Weather weather) {
@@ -60,5 +66,10 @@ public class Match extends BaseEntity {
                 .matchDate(matchDate)
                 .weather(weather)
                 .build();
+    }
+
+    // 매치에 쿼터기록 추가
+    public void addMatchQuarter(MatchQuarter matchQuarter) {
+        matchQuarters.add(matchQuarter);
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/Match.java
+++ b/src/main/java/com/project/Karman/domain/entity/Match.java
@@ -20,34 +20,39 @@ public class Match extends BaseEntity {
     @Column(columnDefinition = "uuid", updatable = false, nullable = false)
     private UUID matchId;
 
-    @Column(nullable = false)
-    private UUID clubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", columnDefinition = "uuid")
+    private Club club;
 
     @Column(nullable = false, length = 50)
     private String opponent;
 
+    @Builder.Default
     @Column(nullable = false)
-    private Integer scoredGoal;
+    private Integer scoredGoal = 0;
 
+    @Builder.Default
     @Column(nullable = false)
-    private Integer concededGoal;
+    private Integer concededGoal = 0;
 
-    @Column(nullable = false, length = 50)
-    private String location;
+    @Builder.Default
+    @Column(length = 50)
+    private String location = null;
 
     @Column(nullable = false)
     private LocalDateTime matchDate;
 
+    @Builder.Default
     @Column(nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
-    private Weather weather;
+    private Weather weather = Weather.SUNNY;
 
 
-    public static Match of(UUID clubId, String opponent, Integer scoredGoal, Integer concededGoal,
+    public static Match of(Club club, String opponent, Integer scoredGoal, Integer concededGoal,
                            String location, LocalDateTime matchDate, Weather weather) {
 
         return Match.builder()
-                .clubId(clubId)
+                .club(club)
                 .opponent(opponent)
                 .scoredGoal(scoredGoal)
                 .concededGoal(concededGoal)

--- a/src/main/java/com/project/Karman/domain/entity/MatchGoal.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchGoal.java
@@ -1,0 +1,51 @@
+package com.project.Karman.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_goal")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID matchGoalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "match_id", referencedColumnName = "match_id"),
+            @JoinColumn(name = "quarter", referencedColumnName = "quarter")
+    })
+    private MatchQuarter matchQuarter;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(name = "scorer_name", nullable = false, length = 50)),
+            @AttributeOverride(name = "affiliationId", column = @Column(name = "scorer_affiliation_id"))
+    })
+    private MatchPlayerInfo scorePlayer;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(name = "assist_name", length = 50)),
+            @AttributeOverride(name = "affiliationId", column = @Column(name = "assist_affiliation_id"))
+    })
+    private MatchPlayerInfo assistPlayer;
+
+
+    public static MatchGoal of(MatchQuarter matchQuarter,  String scorerName, UUID scorerAffiliationId,  String assistPlayerName, UUID assistPlayerAffiliationId) {
+
+        return MatchGoal.builder()
+                .matchQuarter(matchQuarter)
+                .scorePlayer(MatchPlayerInfo.of(scorerName, scorerAffiliationId))
+                .assistPlayer(MatchPlayerInfo.of(assistPlayerName, assistPlayerAffiliationId))
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/domain/entity/MatchLineup.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchLineup.java
@@ -1,0 +1,53 @@
+package com.project.Karman.domain.entity;
+
+import com.project.Karman.domain.enums.Position;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_lineup")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchLineup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID matchLineupId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "match_id", referencedColumnName = "match_id"),
+            @JoinColumn(name = "quarter", referencedColumnName = "quarter")
+    })
+    private MatchQuarter matchQuarter;
+
+    @Column(columnDefinition = "integer", nullable = false)
+    private Integer positionNumber;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isSub = false;
+
+    @Embedded
+    private MatchPlayerInfo playerInfo;
+
+    public static MatchLineup of(MatchQuarter matchQuarter, Integer positionNumber, Position position, Boolean isSub, String name, UUID affiliationId) {
+
+        return MatchLineup.builder()
+                .matchQuarter(matchQuarter)
+                .positionNumber(positionNumber)
+                .position(position)
+                .isSub(isSub)
+                .playerInfo(MatchPlayerInfo.of(name, affiliationId))
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/domain/entity/MatchPlayerInfo.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchPlayerInfo.java
@@ -1,0 +1,31 @@
+package com.project.Karman.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchPlayerInfo {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private UUID affiliationId;
+
+    public static MatchPlayerInfo of(String name, UUID affiliationId) {
+
+        return MatchPlayerInfo.builder()
+                .name(name)
+                .affiliationId(affiliationId)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
@@ -4,6 +4,8 @@ import com.project.Karman.domain.enums.Formation;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -35,6 +37,15 @@ public class MatchQuarter extends BaseEntity {
     @Column(nullable = false)
     private Integer concededGoal = 0;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "matchQuarter", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MatchLineup> lineup = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "matchQuarter", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MatchGoal> scoredGoals = new ArrayList<>();
+
+
     public static MatchQuarter of(UUID matchId, Integer quarter, Match match, Formation formation, Integer concededGoal) {
 
         return MatchQuarter.builder()
@@ -43,5 +54,17 @@ public class MatchQuarter extends BaseEntity {
                 .formation(formation)
                 .concededGoal(concededGoal)
                 .build();
+    }
+
+    public void addLineup(MatchLineup player) {
+        lineup.add(player);
+    }
+
+    public void addScoredGoal(MatchGoal goal) {
+        scoredGoals.add(goal);
+    }
+
+    public void countGoal() {
+        scoredGoal = scoredGoals.size();
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
@@ -1,0 +1,47 @@
+package com.project.Karman.domain.entity;
+
+import com.project.Karman.domain.enums.Formation;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_quarter")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchQuarter extends BaseEntity {
+
+    @EmbeddedId
+    private MatchQuarterId matchQuarterId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("matchId")
+    @JoinColumn(name = "match_id")
+    private Match match;
+
+    @Builder.Default
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Formation formation = Formation.FOUR_THREE_THREE;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer scoredGoal = 0;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer concededGoal = 0;
+
+    public static MatchQuarter of(UUID matchId, Integer quarter, Match match, Formation formation, Integer concededGoal) {
+
+        return MatchQuarter.builder()
+                .matchQuarterId(MatchQuarterId.of(matchId, quarter))
+                .match(match)
+                .formation(formation)
+                .concededGoal(concededGoal)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
@@ -17,7 +17,7 @@ public class MatchQuarterId implements Serializable {
     @Column(name = "match_id", columnDefinition = "uuid", nullable = false)
     private UUID matchId;
 
-    @Column(columnDefinition = "integer", nullable = false)
+    @Column(columnDefinition = "integer", nullable = false, unique = true)
     private Integer quarter;
 
 

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
@@ -1,0 +1,31 @@
+package com.project.Karman.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class MatchQuarterId implements Serializable {
+
+    @Column(name = "match_id", columnDefinition = "uuid", nullable = false)
+    private UUID matchId;
+
+    @Column(columnDefinition = "integer", nullable = false)
+    private Integer quarter;
+
+
+    public static MatchQuarterId of(UUID matchId, Integer quarter) {
+
+        return MatchQuarterId.builder()
+                .matchId(matchId)
+                .quarter(quarter)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/domain/enums/Formation.java
+++ b/src/main/java/com/project/Karman/domain/enums/Formation.java
@@ -1,0 +1,36 @@
+package com.project.Karman.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Formation {
+    FOUR_THREE_THREE("4-3-3"),
+    FOUR_FOUR_TWO("4-4-2"),
+    FOUR_TWO_THREE_ONE("4-2-3-1"),
+    FOUR_ONE_TWO_ONE_TWO("4-1-2-1-2"),
+    FOUR_THREE_TWO_ONE("4-3-2-1"),
+    FOUR_FIVE_ONE("4-5-1"),
+    FOUR_ONE_FOUR_ONE("4-1-4-1"),
+    FOUR_ONE_THREE_TWO("4-1-3-2"),
+    FOUR_THREE_ONE_TWO("4-3-1-2"),
+    THREE_FOUR_THREE("3-4-3"),
+    THREE_FIVE_TWO("3-5-2"),
+    FIVE_THREE_TWO("5-3-2"),
+    NOT_VALID_FORMATION("존재하지 않는 포메이션");
+
+    private final String name;
+
+    Formation(String name) {
+        this.name = name;
+    }
+
+    public static Formation fromName(String name) {
+        for (Formation formation : Formation.values()) {
+            if (formation.getName().equals(name)) {
+                return formation;
+            }
+        }
+
+        return NOT_VALID_FORMATION;
+    }
+}

--- a/src/main/java/com/project/Karman/dto/request/MatchCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchCreateRequestDto.java
@@ -20,7 +20,6 @@ public record MatchCreateRequestDto(
         @NotNull(message = "실점은 필수 입력 값입니다.")
         @PositiveOrZero
         Integer concededGoal,
-        @NotBlank(message = "매치 장소는 필수 입력 값입니다.")
         @Pattern(regexp = "^[A-Za-z0-9가-힣\\- ]+$",
                 message = "위치는 영문, 한글, 숫자, 공백, '-'만 입력 가능합니다.")
         String location,

--- a/src/main/java/com/project/Karman/dto/request/MatchCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchCreateRequestDto.java
@@ -1,10 +1,13 @@
 package com.project.Karman.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.Karman.domain.enums.Weather;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
+
+import java.time.LocalDateTime;
 
 public record MatchCreateRequestDto(
         @NotBlank(message = "상대 팀 이름은 필수 입력 값입니다.")
@@ -13,14 +16,17 @@ public record MatchCreateRequestDto(
         String opponent,
         @NotNull(message = "득점은 필수 입력 값입니다.")
         @PositiveOrZero
-        Integer score,
+        Integer scoredGoal,
         @NotNull(message = "실점은 필수 입력 값입니다.")
         @PositiveOrZero
-        Integer concededScore,
+        Integer concededGoal,
         @NotBlank(message = "매치 장소는 필수 입력 값입니다.")
         @Pattern(regexp = "^[A-Za-z0-9가-힣\\- ]+$",
                 message = "위치는 영문, 한글, 숫자, 공백, '-'만 입력 가능합니다.")
         String location,
+        @NotNull(message = "매치일자는 필수 입력 값입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+        LocalDateTime matchDate,
         @NotNull(message = "날씨는 필수 입력 값입니다.")
         Weather weather) {
 }

--- a/src/main/java/com/project/Karman/dto/request/MatchGoalCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchGoalCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.project.Karman.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record MatchGoalCreateRequestDto(
+        @NotBlank(message = "득점자 이름은 필수 입력 값입니다.")
+        @Size(min = 1, max = 50, message = "득점자 이름은 1자 이상 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "득점자 이름은 한글, 영어, 숫자만 입력 가능합니다.")
+        String scorerName,
+
+        UUID scorerAffiliationId,
+
+        @Size(max = 50, message = "어시스트 선수 이름은 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "어시스트 선수 이름은 한글, 영어, 숫자만 입력 가능합니다.")
+        String assistPlayerName,
+
+        UUID assistPlayerAffiliationId
+) {
+}

--- a/src/main/java/com/project/Karman/dto/request/MatchLineupCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchLineupCreateRequestDto.java
@@ -1,0 +1,27 @@
+package com.project.Karman.dto.request;
+
+import com.project.Karman.domain.enums.Position;
+import jakarta.validation.constraints.*;
+
+import java.util.UUID;
+
+public record MatchLineupCreateRequestDto(
+        @NotNull(message = "포지션 번호는 필수 입력 값입니다.")
+        @Min(value = 1, message = "포지션 번호는 1 이상이어야 합니다.")
+        @Max(value = 11, message = "포지션 번호는 11 이하여야 합니다.")
+        Integer positionNumber,
+
+        @NotNull(message = "포지션은 필수 입력 값입니다.")
+        Position position,
+
+        UUID affiliationId,
+
+        @NotBlank(message = "선수 이름은 필수 입력 값입니다.")
+        @Size(min = 1, max = 50, message = "선수 이름은 1자 이상 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "선수 이름은 한글, 영어, 숫자만 입력 가능합니다.")
+        String name,
+
+        @NotNull(message = "교체 선수 여부는 필수 입력 값입니다.")
+        Boolean isSub
+) {
+}

--- a/src/main/java/com/project/Karman/dto/request/MatchQuarterCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchQuarterCreateRequestDto.java
@@ -1,0 +1,30 @@
+package com.project.Karman.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+public record MatchQuarterCreateRequestDto(
+        @NotNull(message = "쿼터는 필수 입력 값입니다.")
+        @Min(value = 1, message = "쿼터는 1 이상이어야 합니다.")
+        @Max(value = 8, message = "쿼터는 8 이하여야 합니다.")
+        Integer quarter,
+
+        @NotBlank(message = "포메이션은 필수 입력 값입니다.")
+        String formation,
+
+        @NotNull(message = "실점은 필수 입력 값입니다.")
+        @PositiveOrZero(message = "실점은 0 이상이어야 합니다.")
+        Integer concededGoal,
+
+        @NotNull(message = "라인업은 필수 입력 값입니다.")
+        @NotEmpty(message = "라인업은 최소 1명 이상이어야 합니다.")
+        @Size(min = 1, max = 20, message = "라인업은 1명 이상 20명 이하여야 합니다.")
+        @Valid
+        List<MatchLineupCreateRequestDto> lineup,
+
+        @Valid
+        List<MatchGoalCreateRequestDto> goalsInfo
+) {
+}

--- a/src/main/java/com/project/Karman/dto/response/MatchListResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/MatchListResponseDto.java
@@ -1,0 +1,31 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MatchListResponseDto(
+        UUID matchId,
+        String opponent,
+        Integer scoredGoal,
+        Integer concededGoal,
+        LocalDateTime matchDate,
+        String location
+) {
+
+
+    public static MatchListResponseDto of(UUID matchId, String opponent, Integer scoredGoal, Integer concededGoal, LocalDateTime matchDate, String location) {
+
+        return MatchListResponseDto.builder()
+                .matchId(matchId)
+                .opponent(opponent)
+                .scoredGoal(scoredGoal)
+                .concededGoal(concededGoal)
+                .matchDate(matchDate)
+                .location(location)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/exception/ExceptionMessage.java
+++ b/src/main/java/com/project/Karman/exception/ExceptionMessage.java
@@ -13,12 +13,13 @@ public enum ExceptionMessage {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "찾을 수 없는 유저정보 입니다.", 404),
     DUPLICATED_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다.", 409),
     // Club
-    OWNER_CAN_NOT_WITHDRAW_CLUB(HttpStatus.BAD_REQUEST, "구단주는 클럽을 탈퇴할 수 없습니다.",400), // 탈퇴하면 클럽 삭제 되도록 수정
-    ALREADY_JOINED_PLAYER(HttpStatus.BAD_REQUEST,"이미 가입된 선수입니다.", 400),
+    OWNER_CAN_NOT_WITHDRAW_CLUB(HttpStatus.BAD_REQUEST, "구단주는 클럽을 탈퇴할 수 없습니다.", 400), // 탈퇴하면 클럽 삭제 되도록 수정
+    ALREADY_JOINED_PLAYER(HttpStatus.BAD_REQUEST, "이미 가입된 선수입니다.", 400),
     NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "찾을 수 없는 클럽(팀) 입니다.", 404),
     NOT_FOUND_PLAYER_IN_CLUB(HttpStatus.NOT_FOUND, "클럽(팀)에 소속되지 않은 선수 입니다.", 404),
 
     // Match
+    NOT_VALID_FORMATION(HttpStatus.BAD_REQUEST, "등록되지 않은 포메이션입니다.", 400),
     NOT_FOUND_MATCH(HttpStatus.NOT_FOUND, "찾을 수 없는 매치정보 입니다.", 404);
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -19,7 +19,11 @@ public enum SuccessMessage {
     ACCEPT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 승인", 200),
     REJECT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 거부", 200),
     WITHDRAW_CLUB(HttpStatus.OK, "클럽 탈퇴 완료.", 200),
-    GET_PLAYERS_IN_CLUB(HttpStatus.OK, "클럽 소속 선수들 정보 조회", 200);
+    GET_PLAYERS_IN_CLUB(HttpStatus.OK, "클럽 소속 선수들 정보 조회", 200),
+
+    // 매치 서비스
+    CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),
+    GET_MATCH_ALL(HttpStatus.OK, "매치 전체 기록 조회", 200);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -23,7 +23,8 @@ public enum SuccessMessage {
 
     // 매치 서비스
     CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),
-    GET_MATCH_ALL(HttpStatus.OK, "매치 전체 기록 조회", 200);
+    GET_MATCH_ALL(HttpStatus.OK, "매치 전체 기록 조회", 200),
+    CREATE_MATCH_QUARTER(HttpStatus.OK, "쿼터 기록 등록 완료", 200);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -1,5 +1,6 @@
 package com.project.Karman.repository;
 
+import com.project.Karman.domain.entity.Club;
 import com.project.Karman.domain.entity.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +15,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
 
     @Query("""
             SELECT m FROM Match m
-            WHERE m.clubId = :clubId
+            WHERE m.club = :club
             """)
-    List<Match> findAllByClubId(@Param("clubId") UUID clubId);
+    List<Match> findAllByClub(@Param("club") Club club);
 }

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -2,10 +2,19 @@ package com.project.Karman.repository;
 
 import com.project.Karman.domain.entity.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface MatchRepository extends JpaRepository<Match, UUID> {
+
+    @Query("""
+            SELECT m FROM Match m
+            WHERE m.clubId = :clubId
+            """)
+    List<Match> findAllByClubId(@Param("clubId") UUID clubId);
 }

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -1,6 +1,7 @@
 package com.project.Karman.service;
 
 import com.project.Karman.domain.entity.Affiliation;
+import com.project.Karman.domain.entity.Club;
 import com.project.Karman.domain.entity.Match;
 import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.ClubPlayerRole;
@@ -9,6 +10,7 @@ import com.project.Karman.dto.response.MatchListResponseDto;
 import com.project.Karman.exception.CustomException;
 import com.project.Karman.exception.ExceptionMessage;
 import com.project.Karman.repository.AffiliationRepository;
+import com.project.Karman.repository.ClubRepository;
 import com.project.Karman.repository.MatchRepository;
 import com.project.Karman.service.mapper.MatchMapper;
 import lombok.RequiredArgsConstructor;
@@ -23,12 +25,16 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MatchService {
 
+    private final ClubRepository clubRepository;
     private final MatchRepository matchRepository;
     private final AffiliationRepository affiliationRepository;
     private final MatchMapper matchMapper;
 
     @Transactional
     public void createMatch(MatchCreateRequestDto request, UUID clubId, Member member) {
+        // 클럽 조회
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
         // 클럽 소속 선수 여부
         Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId())
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
@@ -37,7 +43,7 @@ public class MatchService {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
         // 매치 객체 생성 & 저장
-        Match match = matchMapper.toEntity(request, clubId);
+        Match match = matchMapper.toEntity(request, club);
         matchRepository.save(match);
     }
 
@@ -48,7 +54,7 @@ public class MatchService {
         List<Match> matchList = matchRepository.findAllByClubId(clubId);
         // dto로 변환
         List<MatchListResponseDto> matchAllDto = new ArrayList<>();
-        for(Match match : matchList) {
+        for (Match match : matchList) {
             MatchListResponseDto matchDto = matchMapper.toDto(match);
             matchAllDto.add(matchDto);
         }

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -1,11 +1,12 @@
 package com.project.Karman.service;
 
-import com.project.Karman.domain.entity.Affiliation;
-import com.project.Karman.domain.entity.Club;
-import com.project.Karman.domain.entity.Match;
-import com.project.Karman.domain.entity.Member;
+import com.project.Karman.domain.entity.*;
 import com.project.Karman.domain.enums.ClubPlayerRole;
+import com.project.Karman.domain.enums.Formation;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.request.MatchGoalCreateRequestDto;
+import com.project.Karman.dto.request.MatchLineupCreateRequestDto;
+import com.project.Karman.dto.request.MatchQuarterCreateRequestDto;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import com.project.Karman.exception.CustomException;
 import com.project.Karman.exception.ExceptionMessage;
@@ -31,10 +32,7 @@ public class MatchService {
     private final MatchMapper matchMapper;
 
     @Transactional
-    public void createMatch(MatchCreateRequestDto request, UUID clubId, Member member) {
-        // 클럽 조회
-        Club club = clubRepository.findById(clubId)
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
+    public void createMatch(MatchCreateRequestDto requestDto, UUID clubId, Member member) {
         // 클럽 소속 선수 여부
         Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId())
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
@@ -42,16 +40,59 @@ public class MatchService {
         if (player.getPlayerRole().equals(ClubPlayerRole.USER)) {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
+        // 클럽 조회
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
         // 매치 객체 생성 & 저장
-        Match match = matchMapper.toEntity(request, club);
+        Match match = matchMapper.toMatchEntity(requestDto, club);
         matchRepository.save(match);
+    }
+
+    @Transactional
+    public void createMatchQuarter(MatchQuarterCreateRequestDto requestDto, UUID clubId, UUID matchId,Member member) {
+        // 클럽 소속 선수 여부
+        Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId())
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
+        // 권한 체크 - USER 는 쿼터 생성불가
+        if (player.getPlayerRole().equals(ClubPlayerRole.USER)) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
+        }
+        // 클럽 조회
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
+        // 매치 조회
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
+        // 포메이션 변환
+        Formation formation = Formation.fromName(requestDto.formation());
+        if (formation.equals(Formation.NOT_VALID_FORMATION)) {
+            throw new CustomException(ExceptionMessage.NOT_VALID_FORMATION);
+        }
+        // 쿼터 생성
+        MatchQuarter matchQuarter = matchMapper.toMatchQuarterEntity(requestDto, match, formation);
+        // 라인업 추가
+        for (MatchLineupCreateRequestDto lineupDto : requestDto.lineup()) {
+            MatchLineup playerInLineup = matchMapper.toMatchQuarterLineupEntity(matchQuarter, lineupDto);
+            matchQuarter.addLineup(playerInLineup);
+        }
+        // 득점 추가
+        for(MatchGoalCreateRequestDto goalDto : requestDto.goalsInfo()) {
+            MatchGoal scoreInfo = matchMapper.toMatchQuarterGoalEntity(matchQuarter, goalDto);
+            matchQuarter.addScoredGoal(scoreInfo);
+        }
+        // 득점 계산
+        matchQuarter.countGoal();
+        // 쿼터 추가
+        match.addMatchQuarter(matchQuarter);
     }
 
     @Transactional(readOnly = true)
     public List<MatchListResponseDto> getMatchAll(Member member, UUID clubId) {
-
+        // 클럽 조회
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
         // 클럽 아이디를 갖고 있는 경기 기록 전부 조회
-        List<Match> matchList = matchRepository.findAllByClubId(clubId);
+        List<Match> matchList = matchRepository.findAllByClub(club);
         // dto로 변환
         List<MatchListResponseDto> matchAllDto = new ArrayList<>();
         for (Match match : matchList) {

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -5,6 +5,9 @@ import com.project.Karman.domain.entity.Match;
 import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.ClubPlayerRole;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.response.MatchListResponseDto;
+import com.project.Karman.exception.CustomException;
+import com.project.Karman.exception.ExceptionMessage;
 import com.project.Karman.repository.AffiliationRepository;
 import com.project.Karman.repository.MatchRepository;
 import com.project.Karman.service.mapper.MatchMapper;
@@ -12,7 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -27,13 +31,28 @@ public class MatchService {
     public void createMatch(MatchCreateRequestDto request, UUID clubId, Member member) {
         // 클럽 소속 선수 여부
         Affiliation player = affiliationRepository.findByClubIdAndMemberId(clubId, member.getMemberId())
-                .orElseThrow(() -> new NoSuchElementException("클럽에 소속되지 않은 선수입니다."));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
         // 권한 체크
         if (player.getPlayerRole().equals(ClubPlayerRole.USER)) {
-            throw new IllegalArgumentException("운영진이 아닌 회원은 매치를 등록할 수 없습니다.");
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
         // 매치 객체 생성 & 저장
         Match match = matchMapper.toEntity(request, clubId);
         matchRepository.save(match);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MatchListResponseDto> getMatchAll(Member member, UUID clubId) {
+
+        // 클럽 아이디를 갖고 있는 경기 기록 전부 조회
+        List<Match> matchList = matchRepository.findAllByClubId(clubId);
+        // dto로 변환
+        List<MatchListResponseDto> matchAllDto = new ArrayList<>();
+        for(Match match : matchList) {
+            MatchListResponseDto matchDto = matchMapper.toDto(match);
+            matchAllDto.add(matchDto);
+        }
+
+        return matchAllDto;
     }
 }

--- a/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
@@ -1,24 +1,27 @@
 package com.project.Karman.service.mapper;
 
-import com.project.Karman.domain.entity.Club;
-import com.project.Karman.domain.entity.Match;
+import com.project.Karman.domain.entity.*;
+import com.project.Karman.domain.enums.Formation;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.request.MatchGoalCreateRequestDto;
+import com.project.Karman.dto.request.MatchLineupCreateRequestDto;
+import com.project.Karman.dto.request.MatchQuarterCreateRequestDto;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MatchMapper {
 
-    public Match toEntity(MatchCreateRequestDto request, Club club) {
+    public Match toMatchEntity(MatchCreateRequestDto requestDto, Club club) {
 
         return Match.of(
                 club,
-                request.opponent(),
-                request.scoredGoal(),
-                request.concededGoal(),
-                request.location(),
-                request.matchDate(),
-                request.weather()
+                requestDto.opponent(),
+                requestDto.scoredGoal(),
+                requestDto.concededGoal(),
+                requestDto.location(),
+                requestDto.matchDate(),
+                requestDto.weather()
 
         );
     }
@@ -32,6 +35,40 @@ public class MatchMapper {
                 match.getConcededGoal(),
                 match.getMatchDate(),
                 match.getLocation()
+        );
+    }
+
+    public MatchQuarter toMatchQuarterEntity(MatchQuarterCreateRequestDto requestDto, Match match, Formation formation) {
+
+        return MatchQuarter.of(
+                match.getMatchId(),
+                requestDto.quarter(),
+                match,
+                formation,
+                requestDto.concededGoal()
+        );
+    }
+
+    public MatchLineup toMatchQuarterLineupEntity(MatchQuarter matchQuarter, MatchLineupCreateRequestDto lineupRequestDto) {
+
+        return MatchLineup.of(
+                matchQuarter,
+                lineupRequestDto.positionNumber(),
+                lineupRequestDto.position(),
+                lineupRequestDto.isSub(),
+                lineupRequestDto.name(),
+                lineupRequestDto.affiliationId()
+        );
+    }
+
+    public MatchGoal toMatchQuarterGoalEntity(MatchQuarter matchQuarter, MatchGoalCreateRequestDto goalDto) {
+
+        return MatchGoal.of(
+                matchQuarter,
+                goalDto.scorerName(),
+                goalDto.scorerAffiliationId(),
+                goalDto.assistPlayerName(),
+                goalDto.assistPlayerAffiliationId()
         );
     }
 }

--- a/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
@@ -2,6 +2,7 @@ package com.project.Karman.service.mapper;
 
 import com.project.Karman.domain.entity.Match;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
+import com.project.Karman.dto.response.MatchListResponseDto;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -14,11 +15,24 @@ public class MatchMapper {
         return Match.of(
                 clubId,
                 request.opponent(),
-                request.score(),
-                request.concededScore(),
+                request.scoredGoal(),
+                request.concededGoal(),
                 request.location(),
+                request.matchDate(),
                 request.weather()
 
+        );
+    }
+
+    public MatchListResponseDto toDto(Match match) {
+
+        return MatchListResponseDto.of(
+                match.getMatchId(),
+                match.getOpponent(),
+                match.getScoredGoal(),
+                match.getConcededGoal(),
+                match.getMatchDate(),
+                match.getLocation()
         );
     }
 }

--- a/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
@@ -1,19 +1,18 @@
 package com.project.Karman.service.mapper;
 
+import com.project.Karman.domain.entity.Club;
 import com.project.Karman.domain.entity.Match;
 import com.project.Karman.dto.request.MatchCreateRequestDto;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 @Component
 public class MatchMapper {
 
-    public Match toEntity(MatchCreateRequestDto request, UUID clubId) {
+    public Match toEntity(MatchCreateRequestDto request, Club club) {
 
         return Match.of(
-                clubId,
+                club,
                 request.opponent(),
                 request.scoredGoal(),
                 request.concededGoal(),


### PR DESCRIPTION
매치 - 쿼터 등록 초기 구현

### MatchQuarter(매치 쿼터 기록)에 대해서 각 쿼터별 정보를 테이블로 만들어 데이터를 관리하려 했습니다.
1. 라인업(포메이션)
2. 득점&도움


처음에 각각의 (1), (2) 테이블의 PK를 복합키로 구성하려했습니다.
하지만, 구현의 복잡성 증가와 지나친 컬럼의 갯수로 구성된 복합키는 비효율적이라고 판단했습니다.
따라서 MatchQuarterLineup, MatchGoal 테이블은 MatchQuarter테이블을 참조하는 자식 테이블로서 단일 PK를 갖는 방향으로 수정하게됐습니다.

- [x] 팀의 매치 전체기록 조회 API 구현 
- [x] 쿼터 등록 초기 API 구현
 - (1) 쿼터 라인업 엔티티 구현
 - (2) 쿼터 득점 엔티티 구현

이후 쿼터 라인업과 득점에 대해서 affiliation정보를 가질 수도 있고 없을 수도 있습니다.
하지만, 현재 affiliation 테이블 또한 PK값을 member와 club의 pk를 복합키로 갖고있기 때문에, 구조상으로 단일 PK를 갖는 구조로 수정할 예정입니다.

변경 후에, Match 디테일 수정 진행