### PR TITLE
[#15] 클럽 통계/선수 조회 API 구현 및 성능 최적화

### DIFF
--- a/src/main/java/com/project/Karman/controller/ClubController.java
+++ b/src/main/java/com/project/Karman/controller/ClubController.java
@@ -5,10 +5,7 @@ import com.project.Karman.dto.request.ClubCreateRequestDto;
 import com.project.Karman.dto.request.ClubUpdateRequestDto;
 import com.project.Karman.dto.request.JoinStatusUpdateRequestDto;
 import com.project.Karman.dto.request.PlayerStatUpdateRequestDto;
-import com.project.Karman.dto.response.ApiResponse;
-import com.project.Karman.dto.response.ClubInfoResponseDto;
-import com.project.Karman.dto.response.PlayersInfoResponse;
-import com.project.Karman.dto.response.SearchClubResponseDto;
+import com.project.Karman.dto.response.*;
 import com.project.Karman.service.ClubService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -78,11 +75,20 @@ public class ClubController {
     }
 
     @GetMapping("/{club_id}/player-list")
-    public ResponseEntity<ApiResponse<List<PlayersInfoResponse>>> getPlayersByClub(@PathVariable(value = "club_id") UUID clubId) {
-        List<PlayersInfoResponse> playersInfo = clubService.findPlayersInfoByClub(clubId);
+    public ResponseEntity<ApiResponse<PlayerInfoListResponseDto>> getPlayerList(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                @PathVariable(value = "club_id") UUID clubId) {
+        PlayerInfoListResponseDto playerInfoList = clubService.getPlayerInfoList(userDetails.getMember(), clubId);
         return ResponseEntity
-                .status(GET_PLAYERS_IN_CLUB.getHttpStatus())
-                .body(ApiResponse.success(GET_PLAYERS_IN_CLUB.getMessage(), playersInfo));
+                .status(GET_PLAYERS_INFO_IN_CLUB.getHttpStatus())
+                .body(ApiResponse.success(GET_PLAYERS_INFO_IN_CLUB.getMessage(), playerInfoList));
+    }
+
+    @GetMapping("/{club_id}/squad")
+    public ResponseEntity<ApiResponse<PlayerSelectListResponseDto>> getPlayerSelectList(@PathVariable(value = "club_id") UUID clubId) {
+        PlayerSelectListResponseDto playerSelectList = clubService.findPlayerSelectList(clubId);
+        return ResponseEntity
+                .status(GET_PLAYER_SELECT_IN_CLUB.getHttpStatus())
+                .body(ApiResponse.success(GET_PLAYER_SELECT_IN_CLUB.getMessage(), playerSelectList));
     }
 
     @PostMapping("/{club_id}/join-requests")

--- a/src/main/java/com/project/Karman/controller/ClubController.java
+++ b/src/main/java/com/project/Karman/controller/ClubController.java
@@ -130,4 +130,13 @@ public class ClubController {
                 .status(UPDATE_PLAYER_INFO.getHttpStatus())
                 .body(ApiResponse.success(UPDATE_PLAYER_INFO.getMessage()));
     }
+
+    @GetMapping("/{club_id}/statics-records")
+    public ResponseEntity<ApiResponse<ClubStaticsRecordsResponseDto>> getStaticsRecords(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                           @PathVariable(value = "club_id") UUID clubId) {
+        ClubStaticsRecordsResponseDto clubStaticsRecordsResponseDto = clubService.getStaticsRecords(userDetails.getMember(), clubId);
+        return ResponseEntity
+                .status(GET_CLUB_STATICS_RECORDS.getHttpStatus())
+                .body(ApiResponse.success(GET_CLUB_STATICS_RECORDS.getMessage() ,clubStaticsRecordsResponseDto));
+    }
 }

--- a/src/main/java/com/project/Karman/controller/MatchController.java
+++ b/src/main/java/com/project/Karman/controller/MatchController.java
@@ -7,17 +7,16 @@ import com.project.Karman.dto.request.MatchQuarterUpdateRequestDto;
 import com.project.Karman.dto.response.ApiResponse;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import com.project.Karman.dto.response.MatchResponseDto;
-import com.project.Karman.exception.SuccessMessage;
 import com.project.Karman.service.MatchService;
 import jakarta.validation.Valid;
 import org.springframework.data.repository.query.Param;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
+
+import static com.project.Karman.exception.SuccessMessage.*;
 
 @RestController
 @RequestMapping("/clubs/{club_id}/matches")
@@ -30,11 +29,13 @@ public class MatchController {
     }
 
     @PostMapping
-    public ResponseEntity<String> createMatch(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<ApiResponse<Void>> createMatch(@AuthenticationPrincipal CustomUserDetails userDetails,
                                               @PathVariable(value = "club_id") UUID clubId,
                                               @Valid @RequestBody MatchCreateRequestDto requestDto) {
         matchService.createMatch(requestDto, clubId, userDetails.getMember());
-        return new ResponseEntity<>("경기 등록 완료", HttpStatus.OK);
+        return ResponseEntity
+                .status(CRATE_MATCH.getHttpStatus())
+                .body(ApiResponse.success(CRATE_MATCH.getMessage()));
     }
 
     @PostMapping("/{match_id}/quarters")
@@ -44,8 +45,8 @@ public class MatchController {
                                                                 @Valid @RequestBody MatchQuarterCreateRequestDto requestDto) {
         matchService.createMatchQuarter(requestDto, clubId, matchId, userDetails.getMember());
         return ResponseEntity
-                .status(SuccessMessage.CREATE_MATCH_QUARTER.getHttpStatus())
-                .body(ApiResponse.success(SuccessMessage.CREATE_MATCH_QUARTER.getMessage()));
+                .status(CREATE_MATCH_QUARTER.getHttpStatus())
+                .body(ApiResponse.success(CREATE_MATCH_QUARTER.getMessage()));
     }
 
     @PatchMapping("/{match_id}/quarters")
@@ -56,8 +57,8 @@ public class MatchController {
                                                                 @Valid @RequestBody MatchQuarterUpdateRequestDto requestDto) {
         matchService.updateMatchQuarter(requestDto, clubId, matchId, userDetails.getMember(), quarter);
         return ResponseEntity
-                .status(SuccessMessage.UPDATE_MATHC_QUARTER.getHttpStatus())
-                .body(ApiResponse.success(SuccessMessage.UPDATE_MATHC_QUARTER.getMessage()));
+                .status(UPDATE_MATCH_QUARTER.getHttpStatus())
+                .body(ApiResponse.success(UPDATE_MATCH_QUARTER.getMessage()));
     }
 
     // 매치 전체 조회
@@ -66,8 +67,8 @@ public class MatchController {
                                                                                 @PathVariable(value = "club_id") UUID clubId) {
        MatchListResponseDto matchAll = matchService.getMatchInfoAll(userDetails.getMember(), clubId);
         return ResponseEntity
-                .status(SuccessMessage.GET_ALL_MATCH_INFO.getHttpStatus())
-                .body(ApiResponse.success(SuccessMessage.GET_ALL_MATCH_INFO.getMessage(), matchAll));
+                .status(GET_ALL_MATCH_INFO.getHttpStatus())
+                .body(ApiResponse.success(GET_ALL_MATCH_INFO.getMessage(), matchAll));
     }
 
     // 매치 상세 조회
@@ -77,7 +78,7 @@ public class MatchController {
                                                                       @PathVariable(value = "match_id") UUID matchId) {
         MatchResponseDto matchResponseDto = matchService.getMatchInfo(userDetails.getMember(), clubId, matchId);
         return ResponseEntity
-                .status(SuccessMessage.GET_MATCH_DETAIL_INFO.getHttpStatus())
-                .body(ApiResponse.success(SuccessMessage.GET_MATCH_DETAIL_INFO.getMessage(), matchResponseDto));
+                .status(GET_MATCH_DETAIL_INFO.getHttpStatus())
+                .body(ApiResponse.success(GET_MATCH_DETAIL_INFO.getMessage(), matchResponseDto));
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/Club.java
+++ b/src/main/java/com/project/Karman/domain/entity/Club.java
@@ -69,7 +69,7 @@ public class Club extends BaseEntity {
     }
 
 
-    public void addPlayer(Affiliation owner) {
-        this.affiliationPlayers.add(owner);
+    public void addPlayer(Affiliation affiliation) {
+        this.affiliationPlayers.add(affiliation);
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarterId.java
@@ -18,7 +18,7 @@ public class MatchQuarterId implements Serializable {
     @Column(name = "match_id", columnDefinition = "uuid", nullable = false)
     private UUID matchId;
 
-    @Column(columnDefinition = "integer", nullable = false, unique = true)
+    @Column(columnDefinition = "integer", nullable = false)
     private Integer quarter;
 
 

--- a/src/main/java/com/project/Karman/dto/response/ClubStaticsRecordsResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/ClubStaticsRecordsResponseDto.java
@@ -1,0 +1,31 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ClubStaticsRecordsResponseDto(
+        // 총 경기수
+        // 총 승,무,패 수
+        // 총 득점
+        // 총 실점
+        Long matchCount,
+        Long win,
+        Long draw,
+        Long lose,
+        Long totalScoreGoal,
+        Long totalConcedeGoal
+) {
+
+    public static ClubStaticsRecordsResponseDto of(Long matchCount, Long win, Long draw, Long lose, Long totalScoreGoal, Long totalConcedeGoal) {
+
+        return ClubStaticsRecordsResponseDto.builder()
+                .matchCount(matchCount)
+                .win(win)
+                .draw(draw)
+                .lose(lose)
+                .totalScoreGoal(totalScoreGoal)
+                .totalConcedeGoal(totalConcedeGoal)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/PlayerInfoListResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/PlayerInfoListResponseDto.java
@@ -1,0 +1,22 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlayerInfoListResponseDto(
+        UUID clubId,
+        List<PlayerInfoResponseDto> playerList
+) {
+
+    public static PlayerInfoListResponseDto of(UUID clubId, List<PlayerInfoResponseDto> playerList) {
+
+        return PlayerInfoListResponseDto.builder()
+                .clubId(clubId)
+                .playerList(playerList)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/PlayerInfoResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/PlayerInfoResponseDto.java
@@ -1,0 +1,37 @@
+package com.project.Karman.dto.response;
+
+import com.project.Karman.domain.enums.Position;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlayerInfoResponseDto(
+        String name,
+        Integer backNumber,
+        Position position,
+        Long matchCount,
+        Long goal,
+        Long assist,
+        Long clear,
+        BigDecimal point,
+        String playerRole
+) {
+
+    public static PlayerInfoResponseDto of(String name, Integer backNumber, Position position, Long matchCount,
+                                           Long goal, Long assist, Long clear, BigDecimal point, String playerRole) {
+
+        return PlayerInfoResponseDto.builder()
+                .name(name)
+                .backNumber(backNumber)
+                .position(position)
+                .matchCount(matchCount)
+                .goal(goal)
+                .assist(assist)
+                .clear(clear)
+                .point(point)
+                .playerRole(playerRole)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/PlayerSelectListResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/PlayerSelectListResponseDto.java
@@ -1,0 +1,22 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlayerSelectListResponseDto(
+        UUID clubId,
+        List<PlayerSelectResponseDto> playerList
+) {
+
+    public static PlayerSelectListResponseDto of(UUID clubId, List<PlayerSelectResponseDto> playerList) {
+
+        return PlayerSelectListResponseDto.builder()
+                .clubId(clubId)
+                .playerList(playerList)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/PlayerSelectResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/PlayerSelectResponseDto.java
@@ -7,16 +7,16 @@ import lombok.Builder;
 import java.util.UUID;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record PlayersInfoResponse(
+public record PlayerSelectResponseDto(
         UUID memberId,
         String name,
         Integer backNumber,
         Position position
 ) {
 
-    public static PlayersInfoResponse of(UUID memberId, String name, Integer backNumber, Position position) {
+    public static PlayerSelectResponseDto of(UUID memberId, String name, Integer backNumber, Position position) {
 
-        return PlayersInfoResponse.builder()
+        return PlayerSelectResponseDto.builder()
                 .memberId(memberId)
                 .name(name)
                 .backNumber(backNumber)

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -22,13 +22,14 @@ public enum SuccessMessage {
     GET_PLAYER_SELECT_IN_CLUB(HttpStatus.OK, "선수 선택목록 조회", 200),
     UPDATE_PLAYER_INFO(HttpStatus.OK, "선수 정보 수정 완료", 200),
     GET_PLAYERS_INFO_IN_CLUB(HttpStatus.OK, "클럽 소속선수 전체기록 조회", 200),
+    GET_CLUB_STATICS_RECORDS(HttpStatus.OK, "클럽 통계 기록 조회", 200),
 
     // 매치 서비스
     CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),
     GET_ALL_MATCH_INFO(HttpStatus.OK, "매치 전체 기록 조회", 200),
     GET_MATCH_DETAIL_INFO(HttpStatus.OK, "매치 상세 기록 조회", 200),
     CREATE_MATCH_QUARTER(HttpStatus.OK, "쿼터 기록 등록 완료", 200),
-    UPDATE_MATHC_QUARTER(HttpStatus.OK, "쿼터 기록 수정 완료", 200);
+    UPDATE_MATCH_QUARTER(HttpStatus.OK, "쿼터 기록 수정 완료", 200);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -19,8 +19,9 @@ public enum SuccessMessage {
     ACCEPT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 승인", 200),
     REJECT_JOIN_CLUB_REQUEST(HttpStatus.OK, "클럽 가입 요청 거부", 200),
     WITHDRAW_CLUB(HttpStatus.OK, "클럽 탈퇴 완료.", 200),
-    GET_PLAYERS_IN_CLUB(HttpStatus.OK, "클럽 소속 선수들 정보 조회", 200),
+    GET_PLAYER_SELECT_IN_CLUB(HttpStatus.OK, "선수 선택목록 조회", 200),
     UPDATE_PLAYER_INFO(HttpStatus.OK, "선수 정보 수정 완료", 200),
+    GET_PLAYERS_INFO_IN_CLUB(HttpStatus.OK, "클럽 소속선수 전체기록 조회", 200),
 
     // 매치 서비스
     CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),

--- a/src/main/java/com/project/Karman/repository/AffiliationRepository.java
+++ b/src/main/java/com/project/Karman/repository/AffiliationRepository.java
@@ -23,6 +23,7 @@ public interface AffiliationRepository extends JpaRepository<Affiliation, UUID> 
 
     @Query("""
             SELECT a FROM Affiliation a
+            JOIN FETCH a.member
             WHERE a.club.clubId = :clubId
             """)
     List<Affiliation> findAllByClub_ClubId(@Param("clubId") UUID clubId);

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -10,9 +10,7 @@ import com.project.Karman.dto.request.ClubCreateRequestDto;
 import com.project.Karman.dto.request.ClubUpdateRequestDto;
 import com.project.Karman.dto.request.JoinStatusUpdateRequestDto;
 import com.project.Karman.dto.request.PlayerStatUpdateRequestDto;
-import com.project.Karman.dto.response.ClubInfoResponseDto;
-import com.project.Karman.dto.response.PlayersInfoResponse;
-import com.project.Karman.dto.response.SearchClubResponseDto;
+import com.project.Karman.dto.response.*;
 import com.project.Karman.exception.CustomException;
 import com.project.Karman.exception.ExceptionMessage;
 import com.project.Karman.repository.MemberRepository;
@@ -44,7 +42,7 @@ public class ClubService {
         // 클럽 객체생성 및 저장
         Club club = clubMapper.toEntity(user, requestDto);
         // 연관관계 객체생성
-        Affiliation owner = affiliationMapper.toEntity(user, club, ClubPlayerRole.OWNER);
+        Affiliation owner = affiliationMapper.toAffiliationEntity(user, club, ClubPlayerRole.OWNER);
         club.addPlayer(owner);
         clubRepository.save(club);
     }
@@ -97,21 +95,27 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public List<PlayersInfoResponse> findPlayersInfoByClub(UUID clubId) {
+    public PlayerInfoListResponseDto getPlayerInfoList(Member member, UUID clubId) {
+
+        if (!clubRepository.existsById(clubId)) {
+            throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
+        }
+
+        List<Affiliation> affiliations = affiliationRepository.findAllByClub_ClubId(clubId);
+
+        return affiliationMapper.toPlayerInfoListDto(clubId, affiliations);
+    }
+
+    @Transactional(readOnly = true)
+    public PlayerSelectListResponseDto findPlayerSelectList(UUID clubId) {
         // 클럽 존재 여부 확인
         if (!clubRepository.existsById(clubId)) {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
         }
         // 클럽에 속한 선수 목록 조회
         List<Affiliation> affiliations = affiliationRepository.findAllByClub_ClubId(clubId);
-        // entity -> dto
-        List<PlayersInfoResponse> playersInfo = new ArrayList<>();
-        for (Affiliation player : affiliations) {
-            PlayersInfoResponse info = affiliationMapper.toDto(player);
-            playersInfo.add(info);
-        }
 
-        return playersInfo;
+        return affiliationMapper.toPlayerSelectListDto(clubId, affiliations);
     }
 
     @Transactional
@@ -127,7 +131,7 @@ public class ClubService {
         Member user = memberRepository.findById(member.getMemberId())
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
         // 가입 신청
-        Affiliation requestJoinMember = affiliationMapper.toEntity(user, club, ClubPlayerRole.USER);
+        Affiliation requestJoinMember = affiliationMapper.toAffiliationEntity(user, club, ClubPlayerRole.USER);
         club.addPlayer(requestJoinMember);
     }
 
@@ -180,8 +184,8 @@ public class ClubService {
         }
         // TODO - 구단주 권한으로 수정 요청 -> 체계적인 수정 필요
         // 구단주로 변경 요청은 거부
-        if(requestDto.playerRole() != null) {
-            if(requestDto.playerRole().equals(ClubPlayerRole.OWNER)) {
+        if (requestDto.playerRole() != null) {
+            if (requestDto.playerRole().equals(ClubPlayerRole.OWNER)) {
                 throw new CustomException(ExceptionMessage.NOT_ALLOWED_OWNER_ROLE);
             }
         }

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -50,7 +50,7 @@ public class ClubService {
     @Transactional(readOnly = true)
     public ClubInfoResponseDto getClubInfo(Member member, UUID clubId) {
         // 클럽 상세조회
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         // TODO - 클럽에 소속한 선수는 디테일 정보 열람가능하도록 수정
 
         return clubMapper.toDto(club);
@@ -59,7 +59,7 @@ public class ClubService {
     @Transactional
     public void modifyClubInfo(Member member, UUID clubId, ClubUpdateRequestDto requestDto) {
         // 클럽 체크
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         // 구단주와 접근 유저 동일 여부 체크
         if (!club.getMember().getMemberId().equals(member.getMemberId())) {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
@@ -73,7 +73,7 @@ public class ClubService {
     @Transactional
     public void deleteClub(Member member, UUID clubId) {
         // 클럽 체크
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         // 구단주와 접근 유저 동일 여부 체크
         if (!club.getMember().getMemberId().equals(member.getMemberId())) {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
@@ -121,7 +121,7 @@ public class ClubService {
     @Transactional
     public void requestJoinClub(Member member, UUID clubId) {
         // 클럽 조회
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         // 유저 조회
         Optional<Affiliation> player = affiliationRepository.findByClub_ClubIdAndMember_MemberId(clubId, member.getMemberId());
         if (player.isPresent()) {
@@ -159,7 +159,7 @@ public class ClubService {
     @Transactional
     public void withdrawClub(Member member, UUID clubId) {
         // 클럽 조회
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         if (club.getMember().getMemberId().equals(member.getMemberId())) {
             throw new CustomException(ExceptionMessage.OWNER_CAN_NOT_WITHDRAW_CLUB);
         }
@@ -198,7 +198,7 @@ public class ClubService {
     }
 
     // 클럽 상세조회
-    private Club findClub(UUID clubId) {
+    private Club findClubById(UUID clubId) {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
     }

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -2,10 +2,12 @@ package com.project.Karman.service;
 
 import com.project.Karman.domain.entity.Affiliation;
 import com.project.Karman.domain.entity.Club;
+import com.project.Karman.domain.entity.Match;
 import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.AgeGroup;
 import com.project.Karman.domain.enums.ClubJoinStatus;
 import com.project.Karman.domain.enums.ClubPlayerRole;
+import com.project.Karman.domain.enums.MatchResult;
 import com.project.Karman.dto.request.ClubCreateRequestDto;
 import com.project.Karman.dto.request.ClubUpdateRequestDto;
 import com.project.Karman.dto.request.JoinStatusUpdateRequestDto;
@@ -40,7 +42,7 @@ public class ClubService {
         Member user = memberRepository.findById(member.getMemberId())
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
         // 클럽 객체생성 및 저장
-        Club club = clubMapper.toEntity(user, requestDto);
+        Club club = clubMapper.toClubEntity(user, requestDto);
         // 연관관계 객체생성
         Affiliation owner = affiliationMapper.toAffiliationEntity(user, club, ClubPlayerRole.OWNER);
         club.addPlayer(owner);
@@ -53,7 +55,7 @@ public class ClubService {
         Club club = findClubById(clubId);
         // TODO - 클럽에 소속한 선수는 디테일 정보 열람가능하도록 수정
 
-        return clubMapper.toDto(club);
+        return clubMapper.toClubInfoDto(club);
     }
 
     @Transactional
@@ -195,6 +197,29 @@ public class ClubService {
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
         // 선수 정보수정
         player.updatePlayerInfo(requestDto.position(), requestDto.backNumber(), requestDto.playerRole());
+    }
+
+    @Transactional(readOnly = true)
+    public ClubStaticsRecordsResponseDto getStaticsRecords(Member member, UUID clubId) {
+        // 클럽 조회
+        Club club = findClubById(clubId);
+        // 수치 계산
+        Long matchCount = (long) club.getMatches().size();
+        Long win = 0L, draw = 0L, lose = 0L;
+        Long scoreGoals = 0L, concedeGoals = 0L;
+        for (Match match : club.getMatches()) {
+            if(match.getMatchResult().equals(MatchResult.WIN)) {
+                win++;
+            } else if(match.getMatchResult().equals(MatchResult.DRAW)) {
+                draw++;
+            } else {
+                lose++;
+            }
+            scoreGoals += match.getScoredGoal();
+            concedeGoals += match.getConcededGoal();
+        }
+
+        return clubMapper.toClubStaticsRecordsDto(matchCount, win, draw, lose, scoreGoals, concedeGoals);
     }
 
     // 클럽 상세조회

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -30,7 +30,7 @@ public class MatchService {
     @Transactional
     public void createMatch(MatchCreateRequestDto requestDto, UUID clubId, Member member) {
         // 클럽 조회
-        Club club = findClub(clubId);
+        Club club = findClubById(clubId);
         // 클럽 소속 선수 여부 & 권한 체크
         validateUserClubRoleIsManagement(clubId, member.getMemberId());
         // 매치 객체 생성 & 저장
@@ -46,12 +46,12 @@ public class MatchService {
         // 2) 클럽 소속 여부 & 권한 체크(운영진 이삼만 쿼터생성 가능)
         validateUserClubRoleIsManagement(clubId, member.getMemberId());
         // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
-        Match match = findMatch(matchId);
+        Match match = findMatchById(matchId);
         // 4) 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
         // TODO - MVP 구현 후 A안 B안 속도 비교
         // 5) 라인업 선수 소속 여부 검증 - A안
-        validateAffiliationIdsInSquads(requestDto.lineup(), requestDto.goalsInfo(), clubId);
+        validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
         // [비즈니스 로직]
         // 포메이션 변환
         Formation formation = Formation.fromName(requestDto.formation());
@@ -78,11 +78,11 @@ public class MatchService {
         // 2) 클럽 소속 여부 & 권한 체크(운영진 이삼만 쿼터생성 가능)
         validateUserClubRoleIsManagement(clubId, member.getMemberId());
         // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
-        Match match = findMatch(matchId);
+        Match match = findMatchById(matchId);
         // 4) 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
         // 5) 라인업 선수 소속 여부 검증
-        validateAffiliationIdsInSquads(requestDto.lineup(), requestDto.goalsInfo(), clubId);
+        validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
         // 쿼터 조회
         MatchQuarter matchQuarter = matchRepository.findMatchQuarterByMatchIdAndQuarter(matchId, quarter)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH_QUARTER));
@@ -105,7 +105,7 @@ public class MatchService {
         updateAffiliationStats(updatedAffiliations);
     }
 
-    private void validateAffiliationIdsInSquads(List<MatchLineupCreateRequestDto> lineupRequestDto, List<MatchGoalCreateRequestDto> goalsInfoRequestDto, UUID clubId) {
+    private void validateAffiliationIdsInSquad(List<MatchLineupCreateRequestDto> lineupRequestDto, List<MatchGoalCreateRequestDto> goalsInfoRequestDto, UUID clubId) {
         // 입력받은 affiliationId 목록
         Set<UUID> affiliationIdsToValidate = getAffiliationIdsFromDto(lineupRequestDto, goalsInfoRequestDto);
         // 검증
@@ -177,8 +177,8 @@ public class MatchService {
         }
     }
 
-    private void updateAffiliationStats(Set<UUID> updatedAffiliationIds) {
-        for (UUID updateAffiliationId : updatedAffiliationIds) {
+    private void updateAffiliationStats(Set<UUID> updateAffiliationIds) {
+        for (UUID updateAffiliationId : updateAffiliationIds) {
             Affiliation updatePlayer = affiliationRepository.findById(updateAffiliationId)
                     .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
 
@@ -220,14 +220,14 @@ public class MatchService {
         // 클럽 조회
         checkClubIsExist(clubId);
         // 매치 조회
-        Match match = findMatch(matchId);
+        Match match = findMatchById(matchId);
         // 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
         // Dto 반환
         return matchMapper.toMatchDto(match);
     }
 
-    private Club findClub(UUID clubId) {
+    private Club findClubById(UUID clubId) {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
     }
@@ -238,7 +238,7 @@ public class MatchService {
         }
     }
 
-    private Match findMatch(UUID matchId) {
+    private Match findMatchById(UUID matchId) {
         return matchRepository.findById(matchId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
     }

--- a/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
@@ -4,24 +4,65 @@ import com.project.Karman.domain.entity.Affiliation;
 import com.project.Karman.domain.entity.Club;
 import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.ClubPlayerRole;
-import com.project.Karman.dto.response.PlayersInfoResponse;
+import com.project.Karman.dto.response.PlayerInfoListResponseDto;
+import com.project.Karman.dto.response.PlayerInfoResponseDto;
+import com.project.Karman.dto.response.PlayerSelectListResponseDto;
+import com.project.Karman.dto.response.PlayerSelectResponseDto;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
 
 @Component
 public class AffiliationMapper {
 
-    public Affiliation toEntity(Member member, Club club, ClubPlayerRole playerRole) {
+    public Affiliation toAffiliationEntity(Member member, Club club, ClubPlayerRole playerRole) {
 
         return Affiliation.of(member, club, playerRole);
     }
 
+    public PlayerSelectResponseDto toPlayerSelectDto(Affiliation affiliation) {
 
-    public PlayersInfoResponse toDto(Affiliation affiliation) {
-
-        return PlayersInfoResponse.of(
+        return PlayerSelectResponseDto.of(
                 affiliation.getMember().getMemberId(),
                 affiliation.getMember().getName(),
                 affiliation.getBackNumber(),
                 affiliation.getPosition());
+    }
+
+    public PlayerSelectListResponseDto toPlayerSelectListDto(UUID clubId, List<Affiliation> affiliations) {
+
+        List<PlayerSelectResponseDto> playerSelectResponseDtoList = affiliations.stream()
+                .map(this::toPlayerSelectDto)
+                .toList();
+
+        return PlayerSelectListResponseDto.of(
+                clubId,
+                playerSelectResponseDtoList);
+    }
+
+    public PlayerInfoResponseDto toPlayerInfoDto(Affiliation affiliation) {
+
+        return PlayerInfoResponseDto.of(
+                affiliation.getMember().getName(),
+                affiliation.getBackNumber(),
+                affiliation.getPosition(),
+                affiliation.getMatchCount(),
+                affiliation.getGoal(),
+                affiliation.getAssist(),
+                affiliation.getClear(),
+                affiliation.getPoint(),
+                affiliation.getPlayerRole().toString());
+    }
+
+    public PlayerInfoListResponseDto toPlayerInfoListDto(UUID clubId, List<Affiliation> affiliations) {
+
+        List<PlayerInfoResponseDto> playerInfoResponseDtoList = affiliations.stream()
+                .map(this::toPlayerInfoDto)
+                .toList();
+
+        return PlayerInfoListResponseDto.of(
+                clubId,
+                playerInfoResponseDtoList);
     }
 }

--- a/src/main/java/com/project/Karman/service/mapper/ClubMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/ClubMapper.java
@@ -5,12 +5,13 @@ import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.AgeGroup;
 import com.project.Karman.dto.response.ClubInfoResponseDto;
 import com.project.Karman.dto.request.ClubCreateRequestDto;
+import com.project.Karman.dto.response.ClubStaticsRecordsResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClubMapper {
 
-    public Club toEntity(Member member, ClubCreateRequestDto request) {
+    public Club toClubEntity(Member member, ClubCreateRequestDto request) {
 
         return Club.of(
                 member,
@@ -20,7 +21,7 @@ public class ClubMapper {
                 request.foundationDate());
     }
 
-    public ClubInfoResponseDto toDto(Club club) {
+    public ClubInfoResponseDto toClubInfoDto(Club club) {
 
         return ClubInfoResponseDto.of(
                 club.getClubId(),
@@ -29,5 +30,16 @@ public class ClubMapper {
                 club.getAgeGroup().toString(),
                 club.getFoundationDate().toString()
         );
+    }
+
+    public ClubStaticsRecordsResponseDto toClubStaticsRecordsDto(Long matchCount, Long win, Long draw, Long lose, Long scoreGoals, Long concedeGoals) {
+
+        return ClubStaticsRecordsResponseDto.of(
+                matchCount,
+                win,
+                draw,
+                lose,
+                scoreGoals,
+                concedeGoals);
     }
 }


### PR DESCRIPTION
## 🎯 작업 내용

### ✨ 새로운 기능
- **클럽 통계 기록 조회 API** 구현(총 경기 수, 승/무/패, 득점/실점 집계 기능)
  
- **선수 전체 목록 조회 API** 구현

### 🔧 리팩토링
- 선수 선택 목록 조회 DTO 구조 개선
- Affiliation 매개변수명 명확성 향상
- 서비스 메서드명 가독성 개선
- 매치 생성 응답 형식 표준화 및 SuccessMessage 적용

### 🐛 버그 수정
- MatchQuarter의 잘못된 unique 제약조건 해제
  - 기존: `quarter` 단일 컬럼에 unique 제약 (전체 매치에서 quarter가 중복 불가)
  - 수정: Primary Key `(match_id, quarter)` 조합만 유지 (같은 매치 내에서만 중복 방지)

## 🚀 성능 개선
- **Fetch Join 적용**으로 N+1 쿼리 문제 해결
  - 선수 목록 조회 시 연관된 Member 정보를 한 번의 쿼리로 조회