### PR TITLE
[#16] 나의소속 클럽목록 조회 api 초기 구현

### DIFF
--- a/src/main/java/com/project/Karman/controller/MemberController.java
+++ b/src/main/java/com/project/Karman/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.project.Karman.controller;
+
+import com.project.Karman.config.security.CustomUserDetails;
+import com.project.Karman.dto.response.ApiResponse;
+import com.project.Karman.dto.response.MyClubListResponseDto;
+import com.project.Karman.exception.SuccessMessage;
+import com.project.Karman.service.ClubService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+
+    private final ClubService clubService;
+
+    public MemberController(ClubService clubService) {
+        this.clubService = clubService;
+    }
+
+
+    @GetMapping("/members/my-club")
+    ResponseEntity<ApiResponse<MyClubListResponseDto>> getMyClubList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        MyClubListResponseDto clubIdListResponseDto = clubService.getMyClubList(userDetails.getMember());
+        return ResponseEntity
+                .status(SuccessMessage.GET_MY_CLUBS.getHttpStatus())
+                .body(ApiResponse.success(SuccessMessage.GET_MY_CLUBS.getMessage(), clubIdListResponseDto));
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/MyClubInfoResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/MyClubInfoResponseDto.java
@@ -1,0 +1,21 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MyClubInfoResponseDto(
+        UUID clubId,
+        String name
+) {
+
+    public static MyClubInfoResponseDto of(UUID clubId, String name) {
+
+        return MyClubInfoResponseDto.builder()
+                .clubId(clubId)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/MyClubListResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/MyClubListResponseDto.java
@@ -1,0 +1,19 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MyClubListResponseDto(
+        List<MyClubInfoResponseDto> clubList
+) {
+
+    public static MyClubListResponseDto of(List<MyClubInfoResponseDto> clubList) {
+
+        return MyClubListResponseDto.builder()
+                .clubList(clubList)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -8,6 +8,7 @@ public enum SuccessMessage {
     // 회원가입, 로그인 성공
     SIGNUP(HttpStatus.OK, "회원가입 완료", 200),
     LOGIN(HttpStatus.OK, "로그인 성공", 200),
+    GET_MY_CLUBS(HttpStatus.OK, "나의 클럽목록 조회", 200),
 
     // 클럽 서비스
     CREATE_CLUB(HttpStatus.OK, "클럽 생성 완료", 200),

--- a/src/main/java/com/project/Karman/repository/ClubRepository.java
+++ b/src/main/java/com/project/Karman/repository/ClubRepository.java
@@ -19,4 +19,10 @@ public interface ClubRepository extends JpaRepository<Club, UUID> {
                 ORDER BY c.clubName ASC
             """)
     List<Club> findAllClubs(@Param("clubName") String clubName);
+
+    @Query("""
+            SELECT a.club FROM Affiliation a
+            WHERE a.member.memberId = :memberId
+            """)
+    List<Club> findAllByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -227,4 +227,12 @@ public class ClubService {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
     }
+
+    @Transactional(readOnly = true)
+    public MyClubListResponseDto getMyClubList(Member member) {
+
+        List<Club> clubs = clubRepository.findAllByMemberId(member.getMemberId());
+
+        return clubMapper.toMyClubListDto(clubs);
+    }
 }

--- a/src/main/java/com/project/Karman/service/mapper/ClubMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/ClubMapper.java
@@ -6,7 +6,11 @@ import com.project.Karman.domain.enums.ClubAgeGroup;
 import com.project.Karman.dto.response.ClubInfoResponseDto;
 import com.project.Karman.dto.request.ClubCreateRequestDto;
 import com.project.Karman.dto.response.ClubStaticsRecordsResponseDto;
+import com.project.Karman.dto.response.MyClubInfoResponseDto;
+import com.project.Karman.dto.response.MyClubListResponseDto;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class ClubMapper {
@@ -41,5 +45,20 @@ public class ClubMapper {
                 lose,
                 scoreGoals,
                 concedeGoals);
+    }
+
+    public MyClubListResponseDto toMyClubListDto(List<Club> clubs) {
+        List<MyClubInfoResponseDto> clubInfoResponseDtoList = clubs.stream()
+                .map(this::toMyClubInfoDto)
+                .toList();
+
+        return MyClubListResponseDto.of(clubInfoResponseDtoList);
+    }
+
+    public MyClubInfoResponseDto toMyClubInfoDto(Club club) {
+
+        return MyClubInfoResponseDto.of(
+                club.getClubId(),
+                club.getClubName());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds GET `/members/my-club` returning the authenticated member's club list.
> 
> - **API**
>   - Adds `GET /members/my-club` in `MemberController` returning `ApiResponse<MyClubListResponseDto>`.
> - **DTOs**
>   - Introduces `MyClubInfoResponseDto` and `MyClubListResponseDto` for club list payloads.
> - **Repository/Service/Mapper**
>   - `ClubRepository`: adds `findAllByMemberId(UUID)` via `Affiliation` query.
>   - `ClubService`: adds `getMyClubList(Member)` using repository and mapper.
>   - `ClubMapper`: maps `Club` to new DTOs and aggregates list.
> - **Messages**
>   - Extends `SuccessMessage` with `GET_MY_CLUBS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf3fe4e95259bd7620b15b8b18ffabf2a9e7307. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->