### PR TITLE
[#17] 매치 상세 조회 쿼리 성능 최적화 v1

### DIFF
--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -17,6 +17,14 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
     List<Match> findAllByClub_ClubIdOrderByMatchDateDesc(UUID clubId);
 
     @Query("""
+            SELECT DISTINCT m FROM Match m
+            LEFT JOIN FETCH m.matchQuarters mq
+            WHERE m.matchId = :matchId
+            ORDER BY mq.matchQuarterId.quarter ASC
+            """)
+    Optional<Match> findByIdWithQuarters(@Param("matchId") UUID matchId);
+
+    @Query("""
             SELECT COUNT(mg) FROM MatchGoal mg
             WHERE mg.matchQuarter.matchQuarterId.matchId = :matchId
             """)

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -214,11 +214,12 @@ public class MatchService {
         // 클럽 조회
         checkClubIsExist(clubId);
         // 매치 조회
-        Match match = findMatchById(matchId);
+        Match match = matchRepository.findByIdWithQuarters(matchId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
         // 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
         // 로그인 유저 클럽 소속 여부 체크
-        if(!isMemberOfClub(clubId, member.getMemberId())) {
+        if (!isMemberOfClub(clubId, member.getMemberId())) {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_ACCESS_MATCH_DATA);
         }
         // 로그인 유저 운영진(Owner or Coach) 여부 판단

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 50
         # 연결 유지 설정
         connection:
           provider_disables_autocommit: false


### PR DESCRIPTION
- MatchRepository에 findByIdWithQuarters 메서드 추가
  - Match와 MatchQuarter를 FETCH JOIN으로 한 번에 조회
  - N+1 문제 해소 및 쿼리 수 감소(10 -> 7)

- application.yml에 default_batch_fetch_size: 50 설정 추가
  - MatchQuarter의 MatchLineup, MatchGoal LAZY 로딩 시 배치 조회
  - 쿼터별 개별 쿼리 대신 IN 절 배치 쿼리로 처리

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves match detail query performance and lowers query count.
> 
> - Adds `MatchRepository.findByIdWithQuarters` using `LEFT JOIN FETCH m.matchQuarters` (ordered by quarter) to load quarters in one query
> - Updates `MatchService.getMatchInfo` to use the new repository method for eager quarter loading
> - Configures Hibernate `default_batch_fetch_size: 50` in `application.yml` to batch lazy collections (e.g., lineups/goals)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcec7fad6f076eeb0841a3b6cb11a1dd48a8d0b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->