### PR TITLE
[#18] Club 도메인 권한 검증 및 통계 조회 성능 개선

### DIFF
--- a/src/main/java/com/project/Karman/repository/AffiliationRepository.java
+++ b/src/main/java/com/project/Karman/repository/AffiliationRepository.java
@@ -22,5 +22,9 @@ public interface AffiliationRepository extends JpaRepository<Affiliation, UUID> 
 
     Boolean existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(UUID clubId, UUID memberId, ClubJoinStatus joinStatus);
 
-    Boolean existsByClub_ClubIdAndMember_MemberIdAndPlayerRoleIn(UUID clubId, UUID memberId, Collection<ClubPlayerRole> playerRoles);
+    boolean existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+            UUID clubId,
+            UUID memberId,
+            ClubJoinStatus joinStatus,
+            Collection<ClubPlayerRole> roles);
 }

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -2,6 +2,8 @@ package com.project.Karman.repository;
 
 import com.project.Karman.domain.entity.Match;
 import com.project.Karman.domain.entity.MatchQuarter;
+import com.project.Karman.domain.enums.MatchResult;
+import com.project.Karman.dto.response.ClubStaticsRecordsResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -62,4 +64,20 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
             """)
     Optional<MatchQuarter> findByMatchQuarterId_MatchIdAndMatchQuarterId_Quarter(@Param("matchId") UUID matchId,
                                                                                  @Param("quarter") Integer quarter);
+
+    @Query("""
+            SELECT COUNT(m),
+                SUM(CASE WHEN m.matchResult = :win THEN 1 ELSE 0 END),
+                SUM(CASE WHEN m.matchResult = :draw THEN 1 ELSE 0 END),
+                SUM(CASE WHEN m.matchResult = :lose THEN 1 ELSE 0 END),
+                COALESCE(SUM(m.scoredGoal), 0),
+                COALESCE(SUM(m.concededGoal), 0)
+            FROM Match m
+            WHERE m.club.clubId = :clubId
+            """)
+    ClubStaticsRecordsResponseDto findClubMatchStatisticsByClubId(
+            UUID clubId,
+            @Param("win") MatchResult win,
+            @Param("draw") MatchResult draw,
+            @Param("lose") MatchResult lose);
 }

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -2,13 +2,13 @@ package com.project.Karman.service;
 
 import com.project.Karman.domain.entity.Affiliation;
 import com.project.Karman.domain.entity.Club;
-import com.project.Karman.domain.entity.Match;
 import com.project.Karman.domain.entity.Member;
 import com.project.Karman.domain.enums.*;
 import com.project.Karman.dto.request.*;
 import com.project.Karman.dto.response.*;
 import com.project.Karman.exception.CustomException;
 import com.project.Karman.exception.ExceptionMessage;
+import com.project.Karman.repository.MatchRepository;
 import com.project.Karman.repository.MemberRepository;
 import com.project.Karman.service.mapper.AffiliationMapper;
 import com.project.Karman.repository.AffiliationRepository;
@@ -26,6 +26,7 @@ public class ClubService {
     private final ClubRepository clubRepository;
     private final MemberRepository memberRepository;
     private final AffiliationRepository affiliationRepository;
+    private final MatchRepository matchRepository;
     private final AffiliationMapper affiliationMapper;
     private final ClubMapper clubMapper;
 
@@ -189,24 +190,10 @@ public class ClubService {
     @Transactional(readOnly = true)
     public ClubStaticsRecordsResponseDto getStaticsRecords(Member member, UUID clubId) {
         // 클럽 조회
-        Club club = findClubById(clubId);
-        // 수치 계산
-        Long matchCount = (long) club.getMatches().size();
-        Long win = 0L, draw = 0L, lose = 0L;
-        Long scoreGoals = 0L, concedeGoals = 0L;
-        for (Match match : club.getMatches()) {
-            if (match.getMatchResult().equals(MatchResult.WIN)) {
-                win++;
-            } else if (match.getMatchResult().equals(MatchResult.DRAW)) {
-                draw++;
-            } else {
-                lose++;
-            }
-            scoreGoals += match.getScoredGoal();
-            concedeGoals += match.getConcededGoal();
+        if (!clubRepository.existsById(clubId)) {
+            throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
         }
-
-        return clubMapper.toClubStaticsRecordsDto(matchCount, win, draw, lose, scoreGoals, concedeGoals);
+        return matchRepository.findClubMatchStatisticsByClubId(clubId, MatchResult.WIN, MatchResult.DRAW, MatchResult.LOSE);
     }
 
     @Transactional

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -32,13 +32,12 @@ public class ClubService {
 
     @Transactional
     public void createClub(Member member, ClubCreateRequestDto requestDto) {
-        // 유저 정보 영속성 컨텍스트
-        Member user = memberRepository.findById(member.getMemberId())
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
+        // 프록시 객체 생성
+        Member ownerMember = memberRepository.getReferenceById(member.getMemberId());
         // 클럽 객체생성 및 저장
-        Club club = clubMapper.toClubEntity(user, requestDto);
+        Club club = clubMapper.toClubEntity(ownerMember, requestDto);
         // 연관관계 객체생성
-        Affiliation owner = affiliationMapper.toAffiliationEntity(club, user, user.getName(), 0,
+        Affiliation owner = affiliationMapper.toAffiliationEntity(club, ownerMember, member.getName(), 0,
                 ClubPlayerPosition.GK, ClubPlayerRole.OWNER, ClubJoinStatus.APPROVED);
         club.addPlayer(owner);
         clubRepository.save(club);
@@ -130,11 +129,10 @@ public class ClubService {
         if (player.isPresent()) {
             throw new CustomException(ExceptionMessage.ALREADY_JOINED_PLAYER);
         }
-        // 연관관계 객체생성
-        Member user = memberRepository.findById(member.getMemberId())
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MEMBER));
+        // 프록시 객체 생성
+        Member joinRequestMember = memberRepository.getReferenceById(member.getMemberId());
         // 가입 신청
-        Affiliation requestJoinMember = affiliationMapper.toAffiliationEntity(club, user, user.getName(), 0,
+        Affiliation requestJoinMember = affiliationMapper.toAffiliationEntity(club, joinRequestMember, member.getName(), 0,
                 ClubPlayerPosition.GK, ClubPlayerRole.USER, ClubJoinStatus.PENDING);
         club.addPlayer(requestJoinMember);
     }

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -100,7 +100,11 @@ public class ClubService {
         // 선수단 조회
         List<Affiliation> affiliations = affiliationRepository.findAllByClub_ClubIdAndJoinStatusOrderByBackNumberAsc(clubId, ClubJoinStatus.APPROVED);
         // 로그인 유저 운영진(Owner or Coach) 여부 판단
-        Boolean isStaff = validateManagementPermission(clubId, member.getMemberId());
+        Boolean isStaff = affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH));
 
         return affiliationMapper.toPlayerInfoListDto(clubId, isStaff, getAffiliationsSortedByPlayerRole(affiliations));
     }
@@ -142,7 +146,7 @@ public class ClubService {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
         }
         // 로그인 유저 권한 체크
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        validateMemberIsManagement(clubId, member.getMemberId());
         // 가입 요청한 선수 정보
         Affiliation player = affiliationRepository.findById(affiliationId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
@@ -173,7 +177,7 @@ public class ClubService {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
         }
         // 로그인 유저 권한 체크
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        validateMemberIsManagement(clubId, member.getMemberId());
         // 타겟 선수
         Affiliation player = affiliationRepository.findById(affiliationId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
@@ -209,7 +213,7 @@ public class ClubService {
         // Club 조회
         Club club = findClubById(clubId);
         // 로그인 유저 권한 체크
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        validateMemberIsManagement(clubId, member.getMemberId());
         // 선수 객체 생성
         Affiliation affiliation = affiliationMapper.toAffiliationEntity(club, null, requestDto.playerName(), requestDto.backNumber(),
                 requestDto.position(), ClubPlayerRole.USER, ClubJoinStatus.APPROVED);
@@ -232,7 +236,7 @@ public class ClubService {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
         }
         // 로그인 유저 권한 체크
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        validateMemberIsManagement(clubId, member.getMemberId());
         // 가입요청 보낸 선수 목록
         List<Affiliation> clubJoinRequestAffiliations = affiliationRepository.findAllByClub_ClubIdAndJoinStatusOrderByBackNumberAsc(clubId, ClubJoinStatus.PENDING);
         return affiliationMapper.toClubJoinRequestListDto(clubId, clubJoinRequestAffiliations);
@@ -251,21 +255,13 @@ public class ClubService {
                 ClubJoinStatus.APPROVED);
     }
 
-    private Boolean validateManagementPermission(UUID clubId, UUID memberId) {
-        return affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndPlayerRoleIn(
+    private void validateMemberIsManagement(UUID clubId, UUID memberId) {
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
                 clubId,
                 memberId,
-                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH));
-    }
-
-    private void validateUserClubRoleIsManagement(UUID clubId, UUID memberId) {
-        // 로그인 유저 클럽 소속여부 체크
-        if (!isMemberOfClub(clubId, memberId)) {
-            throw new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB);
-        }
-        // 클럽에서 로그인 유저 권한 체크
-        if (!validateManagementPermission(clubId, memberId)) {
-            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_UPDATE_CLUB);
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
     }
 

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -88,13 +88,16 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public PlayerInfoListResponseDto getPlayerInfoList(Member member, UUID clubId) {
-        // 로그인 유저 클럽 소속여부 판단
-        if (!isMemberOfClub(clubId, member.getMemberId())) {
-            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_GET_CLUB);
-        }
         // 클럽 존재여부 판단
         if (!clubRepository.existsById(clubId)) {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
+        }
+        // 로그인 유저 클럽 소속여부 판단
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED)) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_GET_CLUB);
         }
         // 선수단 조회
         List<Affiliation> affiliations = affiliationRepository.findAllByClub_ClubIdAndJoinStatusOrderByBackNumberAsc(clubId, ClubJoinStatus.APPROVED);
@@ -244,13 +247,6 @@ public class ClubService {
     private Club findClubById(UUID clubId) {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_CLUB));
-    }
-
-    private Boolean isMemberOfClub(UUID clubId, UUID memberId) {
-        return affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(
-                clubId,
-                memberId,
-                ClubJoinStatus.APPROVED);
     }
 
     private void validateMemberIsManagement(UUID clubId, UUID memberId) {

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -33,7 +33,13 @@ public class MatchService {
         // 클럽 조회
         Club club = findClubById(clubId);
         // 클럽 소속 선수 여부 & 권한 체크
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
+        }
         // 매치 객체 생성 & 저장
         Match match = matchMapper.toMatchEntity(requestDto, club);
         matchRepository.save(match);
@@ -44,8 +50,14 @@ public class MatchService {
         // [검증 로직]
         // 1) 클럽 조회
         checkClubIsExist(clubId);
-        // 2) 클럽 소속 여부 & 권한 체크(운영진 이삼만 쿼터생성 가능)
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        // 2) 클럽 소속 여부 & 권한 체크(운영진 이상부터 생성가능)
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
+        }
         // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
         Match match = findMatchById(matchId);
         // 4) 클럽 경기 여부
@@ -78,7 +90,13 @@ public class MatchService {
         // 1) 클럽 조회
         checkClubIsExist(clubId);
         // 2) 클럽 소속 여부 & 권한 체크(운영진 이삼만 쿼터생성 가능)
-        validateUserClubRoleIsManagement(clubId, member.getMemberId());
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
+        }
         // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
         Match match = findMatchById(matchId);
         // 4) 클럽 경기 여부
@@ -204,7 +222,11 @@ public class MatchService {
         // 클럽 전체 매치 기록 조회
         List<Match> matchList = matchRepository.findAllByClub_ClubIdOrderByMatchDateDesc(clubId);
         // 로그인 유저 운영진(Owner or Coach) 여부 판단
-        Boolean isStaff = validateManagementPermission(clubId, member.getMemberId());
+        Boolean isStaff = affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH));
 
         return matchMapper.toMatchListResponseDto(matchList, isStaff);
     }
@@ -218,12 +240,12 @@ public class MatchService {
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
         // 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
-        // 로그인 유저 클럽 소속 여부 체크
-        if (!isMemberOfClub(clubId, member.getMemberId())) {
-            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_ACCESS_MATCH_DATA);
-        }
-        // 로그인 유저 운영진(Owner or Coach) 여부 판단
-        Boolean isStaff = validateManagementPermission(clubId, member.getMemberId());
+        // 로그인 유저 클럽 소속 여부 체크 + 운영진(Owner or Coach) 여부 판단
+        Boolean isStaff = affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH));
         // Dto 반환
         return matchMapper.toMatchDto(match, isStaff);
     }
@@ -247,31 +269,6 @@ public class MatchService {
     private void checkMatchBelongToClub(UUID matchClubId, UUID clubId) {
         if (!matchClubId.equals(clubId)) {
             throw new CustomException(ExceptionMessage.MATCH_NOT_BELONG_TO_CLUB);
-        }
-    }
-
-    private Boolean isMemberOfClub(UUID clubId, UUID memberId) {
-        return affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(
-                clubId,
-                memberId,
-                ClubJoinStatus.APPROVED);
-    }
-
-    private Boolean validateManagementPermission(UUID clubId, UUID memberId) {
-        return affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndPlayerRoleIn(
-                clubId,
-                memberId,
-                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH));
-    }
-
-    private void validateUserClubRoleIsManagement(UUID clubId, UUID memberId) {
-        // 로그인 유저 클럽 소속여부 체크
-        if (!isMemberOfClub(clubId, memberId)) {
-            throw new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB);
-        }
-        // 클럽에서 로그인 유저 권한 체크
-        if (!validateManagementPermission(clubId, memberId)) {
-            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_USER_ACCESS_MATCH_DATA);
         }
     }
 }


### PR DESCRIPTION
## 📌 개요
- 클럽 도메인에서 반복적으로 발생하던 불필요한 쿼리 및 메모리 로딩 제거
- 권한 검증 및 통계 조회 로직을 DB 집계 중심으로 개선

## 🛠️ 주요 변경 사항
- 운영진 권한 검증 쿼리 통합 (2 → 1)
- 클럽 생성/가입 요청 시 Member 재조회 제거
- 클럽 소속 선수 조회 API 검증 순서 정리
- 클럽 통계 조회를 Match 집계 쿼리로 전환

## ✨ 기대 효과
- 쿼리 수 감소 및 DB 부하 감소
- 대용량 데이터에서도 안정적인 성능



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines permission validation and shifts statistics computation to the database for fewer queries and better performance.
> 
> - Consolidates management checks in `ClubService` and `MatchService` using `AffiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(...)`; removes old helper methods and updates call sites
> - Reorders validations (e.g., club existence before membership) and standardizes permission exceptions
> - Uses `MemberRepository.getReferenceById` in club creation/join flow to avoid redundant member fetches
> - Adds `MatchRepository.findClubMatchStatisticsByClubId(...)` and uses it in `ClubService.getStaticsRecords`; removes manual iteration over matches
> - Updates `AffiliationRepository` signature (include `joinStatus`, return primitive `boolean`) for role checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf6f3e4f9f1209dc479740ea61b125eb673e3347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->