### PR TITLE
[#19] Match 쿼터 생성/수정 성능 개선(v1) 및 매치 조회/집계 로직 개선

### DIFF
--- a/src/main/java/com/project/Karman/domain/entity/Affiliation.java
+++ b/src/main/java/com/project/Karman/domain/entity/Affiliation.java
@@ -3,6 +3,7 @@ package com.project.Karman.domain.entity;
 import com.project.Karman.domain.enums.ClubJoinStatus;
 import com.project.Karman.domain.enums.ClubPlayerPosition;
 import com.project.Karman.domain.enums.ClubPlayerRole;
+import com.project.Karman.domain.vo.PlayerStatsDelta;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -92,15 +93,9 @@ public class Affiliation extends BaseEntity {
         this.backNumber = updatedBackNumber == null ? this.backNumber : updatedBackNumber;
     }
 
-    public void updateMatchCount(Long updatedMatchCount) {
-        this.matchCount = updatedMatchCount;
-    }
-
-    public void updateGoal(Long updatedGoal) {
-        this.goal = updatedGoal;
-    }
-
-    public void updateAssist(Long updatedAssist) {
-        this.assist = updatedAssist;
+    public void applyDelta(PlayerStatsDelta delta) {
+        this.matchCount += delta.getMatchCount();
+        this.goal += delta.getGoal();
+        this.assist += delta.getAssist();
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/Match.java
+++ b/src/main/java/com/project/Karman/domain/entity/Match.java
@@ -77,16 +77,16 @@ public class Match extends BaseEntity {
         matchQuarters.add(matchQuarter);
     }
 
-
     public void updateScore(Long updateScoredGoal, Long updatedConcededGoal) {
-        if (updateScoredGoal > updatedConcededGoal) {
+        this.scoredGoal += updateScoredGoal;
+        this.concededGoal += updatedConcededGoal;
+
+        if (this.scoredGoal > this.concededGoal) {
             this.matchResult = MatchResult.WIN;
-        } else if (updateScoredGoal < updatedConcededGoal) {
+        } else if (this.scoredGoal < this.concededGoal) {
             this.matchResult = MatchResult.LOSE;
         } else {
             this.matchResult = MatchResult.DRAW;
         }
-        this.scoredGoal = updateScoredGoal;
-        this.concededGoal = updatedConcededGoal;
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/Match.java
+++ b/src/main/java/com/project/Karman/domain/entity/Match.java
@@ -77,7 +77,7 @@ public class Match extends BaseEntity {
         matchQuarters.add(matchQuarter);
     }
 
-    public void updateScore(Long updateScoredGoal, Long updatedConcededGoal) {
+    public void addScore(Long updateScoredGoal, Long updatedConcededGoal) {
         this.scoredGoal += updateScoredGoal;
         this.concededGoal += updatedConcededGoal;
 

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
@@ -46,13 +46,12 @@ public class MatchQuarter extends BaseEntity {
     private List<MatchGoal> scoredGoals = new ArrayList<>();
 
 
-    public static MatchQuarter of(UUID matchId, Integer quarter, Match match, MatchFormation matchFormation, Long concededGoal) {
+    public static MatchQuarter of(UUID matchId, Integer quarter, Match match, MatchFormation matchFormation) {
 
         return MatchQuarter.builder()
                 .matchQuarterId(MatchQuarterId.of(matchId, quarter))
                 .match(match)
                 .matchFormation(matchFormation)
-                .concededGoal(concededGoal)
                 .build();
     }
 
@@ -64,13 +63,8 @@ public class MatchQuarter extends BaseEntity {
         scoredGoals.add(goal);
     }
 
-    public void update(MatchFormation matchFormation, Long concededGoal) {
-        if(matchFormation != null) this.matchFormation = matchFormation;
-        if(concededGoal != null) this.concededGoal = concededGoal;
-    }
-
-    public void clearQuarterData() {
-        this.lineup.clear();
-        this.scoredGoals.clear();
+    public void updateScore(Long scoredGoal, Long concededGoal) {
+        this.scoredGoal = scoredGoal;
+        this.concededGoal = concededGoal;
     }
 }

--- a/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
+++ b/src/main/java/com/project/Karman/domain/entity/MatchQuarter.java
@@ -67,4 +67,8 @@ public class MatchQuarter extends BaseEntity {
         this.scoredGoal = scoredGoal;
         this.concededGoal = concededGoal;
     }
+
+    public void updateFormation(MatchFormation formation) {
+        this.matchFormation = formation;
+    }
 }

--- a/src/main/java/com/project/Karman/domain/vo/MatchScoreDelta.java
+++ b/src/main/java/com/project/Karman/domain/vo/MatchScoreDelta.java
@@ -1,0 +1,15 @@
+package com.project.Karman.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public class MatchScoreDelta {
+
+    private final long scoreGoal;
+    private final long concedeGoal;
+
+    public MatchScoreDelta(long scoreGoal, long concedeGoal) {
+        this.scoreGoal = scoreGoal;
+        this.concedeGoal = concedeGoal;
+    }
+}

--- a/src/main/java/com/project/Karman/domain/vo/PlayerStatsDelta.java
+++ b/src/main/java/com/project/Karman/domain/vo/PlayerStatsDelta.java
@@ -26,4 +26,16 @@ public class PlayerStatsDelta {
     public void addAssist() {
         this.assist++;
     }
+
+    public void minusMatchCount() {
+        this.matchCount--;
+    }
+
+    public void minusGoal() {
+        this.goal--;
+    }
+
+    public void minusAssist() {
+        this.assist--;
+    }
 }

--- a/src/main/java/com/project/Karman/domain/vo/PlayerStatsDelta.java
+++ b/src/main/java/com/project/Karman/domain/vo/PlayerStatsDelta.java
@@ -1,0 +1,29 @@
+package com.project.Karman.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public class PlayerStatsDelta {
+
+    private long matchCount;
+    private long goal;
+    private long assist;
+
+    public PlayerStatsDelta(long matchCount, long goal, long assist) {
+        this.matchCount = matchCount;
+        this.goal = goal;
+        this.assist = assist;
+    }
+
+    public void addMatchCount() {
+        this.matchCount++;
+    }
+
+    public void addGoal() {
+        this.goal++;
+    }
+
+    public void addAssist() {
+        this.assist++;
+    }
+}

--- a/src/main/java/com/project/Karman/dto/request/MatchGoalCreateRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/MatchGoalCreateRequestDto.java
@@ -16,8 +16,8 @@ public record MatchGoalCreateRequestDto(
 
         @Size(max = 50, message = "어시스트 선수 이름은 50자 이하여야 합니다.")
         @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "어시스트 선수 이름은 한글, 영어, 숫자만 입력 가능합니다.")
-        String assistPlayerName,
+        String assistName,
 
-        UUID assistPlayerAffiliationId
+        UUID assistAffiliationId
 ) {
 }

--- a/src/main/java/com/project/Karman/exception/ExceptionMessage.java
+++ b/src/main/java/com/project/Karman/exception/ExceptionMessage.java
@@ -29,6 +29,7 @@ public enum ExceptionMessage {
     NOT_FOUND_MATCH(HttpStatus.NOT_FOUND, "찾을 수 없는 매치정보 입니다.", 404),
     NOT_FOUND_MATCH_QUARTER(HttpStatus.NOT_FOUND, "찾을 수 없는 매치의 쿼터정보 입니다.", 404),
     NOT_INCLUDED_PLAYER_IN_LINEUP(HttpStatus.NOT_FOUND, "라인업에 포함되지 않은 선수입니다.", 404),
+    PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD(HttpStatus.BAD_REQUEST, "골 기록은 라인업에 포함된 선수만 가능합니다.", 400),
 
     CREATE_AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ai 응답생성 중 문제가 발생했습니다.", 500);
 

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -21,29 +21,43 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
 
     List<Match> findAllByClub_ClubIdOrderByMatchDateDesc(UUID clubId);
 
+    boolean existsByClub_ClubIdAndMatchId(UUID clubId, UUID matchId);
+
     @Query("""
-            SELECT DISTINCT m FROM Match m
+            SELECT DISTINCT m
+            FROM Match m
             LEFT JOIN FETCH m.matchQuarters mq
             WHERE m.matchId = :matchId
             ORDER BY mq.matchQuarterId.quarter ASC
             """)
     Optional<Match> findByIdWithQuarters(@Param("matchId") UUID matchId);
 
-    boolean existsByClub_ClubIdAndMatchId(UUID clubId, UUID matchId);
-
     @Query("""
-            SELECT DISTINCT ml.playerInfo.affiliationId FROM MatchLineup ml
+            SELECT DISTINCT ml.playerInfo.affiliationId
+            FROM MatchLineup ml
             JOIN ml.matchQuarter mq
             WHERE mq.matchQuarterId.matchId = :matchId
-            AND ml.playerInfo.affiliationId IS NOT NULL
+                AND ml.playerInfo.affiliationId IS NOT NULL
             """)
     Set<UUID> findPlayedAffiliationIdsByMatchId(@Param("matchId") UUID matchId);
 
+    @Query("""
+            SELECT DISTINCT ml.playerInfo.affiliationId
+            FROM MatchLineup ml
+            WHERE ml.matchQuarter.matchQuarterId.matchId = :matchId
+              AND ml.matchQuarter.matchQuarterId.quarter <> :quarter
+              AND ml.playerInfo.affiliationId IS NOT NULL
+            """)
+    Set<UUID> findPlayedAffiliationIdsInOtherQuarters(
+            @Param("matchId") UUID matchId,
+            @Param("quarter") Integer quarter);
+
     // matchQuarter Repository 생성 보류
     @Query("""
-            SELECT mq FROM MatchQuarter mq
+            SELECT mq
+            FROM MatchQuarter mq
             WHERE mq.matchQuarterId.matchId = :matchId
-            AND mq.matchQuarterId.quarter = :quarter
+                AND mq.matchQuarterId.quarter = :quarter
             """)
     Optional<MatchQuarter> findByMatchQuarterId_MatchIdAndMatchQuarterId_Quarter(@Param("matchId") UUID matchId,
                                                                                  @Param("quarter") Integer quarter);

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 @Repository
 public interface MatchRepository extends JpaRepository<Match, UUID> {
 
+    Optional<Match> findByClub_ClubIdAndMatchId(UUID clubId, UUID matchId);
+
     List<Match> findAllByClub_ClubIdOrderByMatchDateDesc(UUID clubId);
 
     @Query("""

--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
@@ -29,34 +30,12 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
     boolean existsByClub_ClubIdAndMatchId(UUID clubId, UUID matchId);
 
     @Query("""
-            SELECT COUNT(mg) FROM MatchGoal mg
-            WHERE mg.matchQuarter.matchQuarterId.matchId = :matchId
-            """)
-    Long countGoalsByMatchId(@Param("matchId") UUID matchId);
-
-    @Query("""
-            SELECT COALESCE(SUM(mq.concededGoal), 0) FROM MatchQuarter mq
+            SELECT DISTINCT ml.playerInfo.affiliationId FROM MatchLineup ml
+            JOIN ml.matchQuarter mq
             WHERE mq.matchQuarterId.matchId = :matchId
+            AND ml.playerInfo.affiliationId IS NOT NULL
             """)
-    Long countConcededGoalsByMatchId(@Param("matchId") UUID matchId);
-
-    @Query("""
-            SELECT COUNT(mg) FROM MatchGoal mg
-            WHERE mg.scorePlayer.affiliationId = :affiliationId
-            """)
-    Long countGoalsByAffiliationId(@Param("affiliationId") UUID affiliationId);
-
-    @Query("""
-            SELECT COUNT(mg) FROM MatchGoal mg
-            WHERE mg.assistPlayer.affiliationId = :affiliationId
-            """)
-    Long countAssistsByAffiliationId(@Param("affiliationId") UUID affiliationId);
-
-    @Query("""
-            SELECT COUNT(DISTINCT(ml.matchQuarter.matchQuarterId.matchId)) FROM MatchLineup ml
-            WHERE ml.playerInfo.affiliationId = :affiliationId
-            """)
-    Long countPlayedMatchesByAffiliationId(@Param("affiliationId") UUID affiliationId);
+    Set<UUID> findPlayedAffiliationIdsByMatchId(@Param("matchId") UUID matchId);
 
     // matchQuarter Repository 생성 보류
     @Query("""

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -77,7 +77,7 @@ public class MatchService {
 
         // 7) 쿼터 생성
         MatchQuarter matchQuarter = matchMapper.toMatchQuarterEntity(
-                requestDto, match, MatchFormation.fromName(requestDto.formation()));
+                match, requestDto.quarter(), MatchFormation.fromName(requestDto.formation()));
 
         // 8) 델타 준비
         MatchScoreDelta matchScoreDelta = new MatchScoreDelta(requestDto.goalsInfo().size(), requestDto.concededGoal());
@@ -123,11 +123,13 @@ public class MatchService {
             }
         }
 
+        matchQuarter.updateScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
+
         // 11) match에 쿼터 추가
         match.addMatchQuarter(matchQuarter);
 
         // 12) Match 스코어 증분 반영
-        match.updateScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
+        match.addScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
 
         // 13) Affiliation 스탯 증분 반영 (한 번에 조회 후 더티체킹)
         applyAffiliationDeltas(playerStatsDeltaMap);
@@ -157,7 +159,6 @@ public class MatchService {
 
     @Transactional
     public void updateMatchQuarter(MatchQuarterUpdateRequestDto requestDto, UUID clubId, UUID matchId, Member member, Integer quarter) {
-
 
     }
 
@@ -192,49 +193,6 @@ public class MatchService {
             // 아이디 수가 일치하지 않으면 정상적이지 않은 affiliationId가 포함된 상황
             if (validAffiliations.size() != affiliationIdsToValidate.size()) {
                 throw new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB);
-            }
-        }
-    }
-
-    private void calculateMatchScore(Match match, MatchScoreDelta matchScoreDelta) {
-        log.info("매치 점수 계산합니다잉");
-        // 업데이트 스코어
-        match.updateScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
-    }
-
-    private void calculateAffiliationStats(Set<UUID> updateAffiliationIds) {
-
-        log.info("#### 선수 스탯 업데이트 시작합니다잉####");
-
-    }
-
-    private void addQuarterLineup(Set<UUID> updatedAffiliations, List<MatchLineupCreateRequestDto> lineup, MatchQuarter matchQuarter) {
-        log.info("#####---쿼터 라인업 생성 및 추가---#####");
-        for (MatchLineupCreateRequestDto lineupDto : lineup) {
-            // 출전선수 정보 생성
-            MatchLineup playerInLineup = matchMapper.toMatchLineupEntity(matchQuarter, lineupDto);
-            matchQuarter.addLineup(playerInLineup);
-            // 소속 선수
-            if (lineupDto.affiliationId() != null) {
-                updatedAffiliations.add(lineupDto.affiliationId());
-            }
-        }
-    }
-
-    private void addQuarterGoalAndAssist(List<MatchGoalCreateRequestDto> goalsInfo, MatchQuarter matchQuarter) {
-        log.info("#####---쿼터 골/도움 기록 생성 및 추가---#####");
-        for (MatchGoalCreateRequestDto goalDto : goalsInfo) {
-            // 득점 정보 객체 생성 및 저장
-            MatchGoal scoreInfo = matchMapper.toMatchGoalEntity(matchQuarter, goalDto);
-            matchQuarter.addScoredGoal(scoreInfo);
-        }
-    }
-
-    private void addAffectedAffiliationIds(Set<UUID> updatedAffiliations, List<MatchLineup> matchLineup) {
-
-        for (MatchLineup ml : matchLineup) {
-            if (ml.getPlayerInfo().getAffiliationId() != null) {
-                updatedAffiliations.add(ml.getPlayerInfo().getAffiliationId());
             }
         }
     }

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -16,8 +16,7 @@ import com.project.Karman.repository.ClubRepository;
 import com.project.Karman.repository.MatchRepository;
 import com.project.Karman.service.mapper.MatchMapper;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,9 +24,9 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MatchService {
 
-    private static final Logger log = LoggerFactory.getLogger(MatchService.class);
     private final ClubRepository clubRepository;
     private final MatchRepository matchRepository;
     private final AffiliationRepository affiliationRepository;
@@ -159,7 +158,162 @@ public class MatchService {
 
     @Transactional
     public void updateMatchQuarter(MatchQuarterUpdateRequestDto requestDto, UUID clubId, UUID matchId, Member member, Integer quarter) {
+        // 1) 조회 및 권한 체크
+        // 클럽 조회
+        checkClubIsExist(clubId);
 
+        // 유저 권한 체크
+        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
+                clubId,
+                member.getMemberId(),
+                ClubJoinStatus.APPROVED,
+                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
+            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
+        }
+
+        // TODO - fetch join 고려 -> MatchQuarter 정보
+        // 매치 쿼터 조회
+        MatchQuarter matchQuarter = matchRepository.findByMatchQuarterId_MatchIdAndMatchQuarterId_Quarter(matchId, quarter)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH_QUARTER));
+
+        long beforeScores = matchQuarter.getScoredGoals().size(), beforeConcedes = matchQuarter.getConcededGoal();
+        long afterScores = requestDto.goalsInfo().size(), afterConcedes = requestDto.concededGoal();
+
+        // 매치 스코어 증분 데이터
+        MatchScoreDelta matchScoreDelta = new MatchScoreDelta(afterScores - beforeScores, afterConcedes - beforeConcedes);
+
+        // update 라인업 유효성 검사
+        validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
+
+        // 선수 스탯 증분 데이터
+        Map<UUID, PlayerStatsDelta> playerStatsDeltaMap = new HashMap<>();
+
+        log.info("#####--- 기존 선수 Delta 만들기 시작 ---#####");
+        // 기존 쿼터 출전 라인업
+        Set<UUID> removePlayerIds = new HashSet<>();    // 제거 대상 선수 아이디
+        // 기존 출전 선수 증분 데이터 생성
+        for (MatchLineup beforePlayer : matchQuarter.getLineup()) {
+            UUID playerId = beforePlayer.getPlayerInfo().getAffiliationId();
+
+            if (playerId != null) {
+                removePlayerIds.add(playerId);
+                if (!playerStatsDeltaMap.containsKey(playerId)) {
+                    playerStatsDeltaMap.put(playerId, new PlayerStatsDelta(0, 0, 0));
+                }
+            }
+        }
+        // 기존 쿼터 출전 라인업 제거
+        matchQuarter.getLineup().clear();
+        log.info("#####--- 기존 선수 Delta 만들기 종료 ---#####");
+
+        log.info("#####--- 기존 선수 Delta 골/도움 -1  시작 ---#####");
+        // 기존 쿼터 선수 득점/도움 차감
+        for (MatchGoal beforeGoal : matchQuarter.getScoredGoals()) {
+            UUID scorerId = beforeGoal.getScorePlayer().getAffiliationId();
+            if (scorerId != null) {
+                if (!playerStatsDeltaMap.containsKey(scorerId)) {
+                    playerStatsDeltaMap.put(scorerId, new PlayerStatsDelta(0, 0, 0));
+                }
+                playerStatsDeltaMap.get(scorerId).minusGoal();
+            }
+
+            UUID assistId = beforeGoal.getAssistPlayer().getAffiliationId();
+            if (assistId != null) {
+                if (!playerStatsDeltaMap.containsKey(assistId)) {
+                    playerStatsDeltaMap.put(assistId, new PlayerStatsDelta(0, 0, 0));
+                }
+                playerStatsDeltaMap.get(assistId).minusAssist();
+            }
+        }
+        // 기존 쿼터 선수 골/도움 제거
+        matchQuarter.getScoredGoals().clear();
+        log.info("#####--- 기존 선수 Delta 골/도움 -1  종료 ---#####");
+
+        Set<UUID> intersectionIds = new HashSet<>();    // 수정 전후 모두 출전한 선수 ID
+        Set<UUID> addPlayerIds = new HashSet<>();       // 매치에 처음 출전하는 선수 ID
+
+        log.info("#####--- 수정 MatchLineup 생성 시작 ---#####");
+        // 새로운 출전 선수 증분 데이터 생성
+        for (MatchLineupCreateRequestDto afterPlayer : requestDto.lineup()) {
+            MatchLineup matchLineup = matchMapper.toMatchLineupEntity(matchQuarter, afterPlayer);
+            matchQuarter.addLineup(matchLineup);
+
+            UUID playerId = afterPlayer.affiliationId();
+            if (playerId != null) {
+                addPlayerIds.add(playerId);
+                if (removePlayerIds.contains(playerId)) {
+                    intersectionIds.add(playerId);
+                }
+
+                if (!playerStatsDeltaMap.containsKey(playerId)) {
+                    playerStatsDeltaMap.put(playerId, new PlayerStatsDelta(0, 0, 0));
+                }
+            }
+        }
+        log.info("#####--- 수정 MatchLineup 생성 종료 ---#####");
+
+        removePlayerIds.removeAll(intersectionIds); // 출전 안하게 되는 선수 목록 matchCount--
+        addPlayerIds.removeAll(intersectionIds);    // 출전 하게 되는 선수 목록 matchCount++
+
+
+        log.info("#####---현재 쿼터를 제외한 나머지 쿼터를 뛴 선수들 찾기---#####");
+        // 현재 쿼터를 제외한 다른 쿼터의 출전 선수 명단 확보
+        Set<UUID> playedIdsInOtherQuarters = matchRepository.findPlayedAffiliationIdsInOtherQuarters(matchId, quarter);
+
+        log.info("#####--- matchCount(경기 수) 가감 진행 ---#####");
+        // 출전 안하게 되는 선수 목록
+        for (UUID playerId : removePlayerIds) {
+            // 다른 쿼터에 뛴적 없는 선수라면 matchCount--
+            if (!playedIdsInOtherQuarters.contains(playerId)) {
+                playerStatsDeltaMap.get(playerId).minusMatchCount();
+            }
+        }
+        // 출전 하게 되는 선수 목록
+        for (UUID playerId : addPlayerIds) {
+            // 다른 쿼터에 뛴적 없는 선수라면 matchCount++
+            if (!playedIdsInOtherQuarters.contains(playerId)) {
+                playerStatsDeltaMap.get(playerId).addMatchCount();
+            }
+        }
+        log.info("#####--- matchCount(경기 수) 가감 종료 ---#####");
+
+
+        log.info("#####--- 수정 MatchGoal 생성 시작 ---#####");
+        // 새로운 선수 득점/도움 데이터 추가
+        for (MatchGoalCreateRequestDto goalInfo : requestDto.goalsInfo()) {
+            MatchGoal matchGoal = matchMapper.toMatchGoalEntity(matchQuarter, goalInfo);
+            matchQuarter.addScoredGoal(matchGoal);
+
+            UUID scorerId = goalInfo.scorerAffiliationId();
+            if (scorerId != null) {
+                if (playerStatsDeltaMap.containsKey(scorerId)) {
+                    playerStatsDeltaMap.get(scorerId).addGoal();
+                } else {
+                    throw new CustomException(ExceptionMessage.PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD);
+                }
+            }
+
+            UUID assistId = goalInfo.assistPlayerAffiliationId();
+            if (assistId != null) {
+                if (playerStatsDeltaMap.containsKey(assistId)) {
+                    playerStatsDeltaMap.get(assistId).addAssist();
+                } else {
+                    throw new CustomException(ExceptionMessage.PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD);
+                }
+            }
+        }
+        log.info("#####--- 수정 MatchGoal 생성 종료 ---#####");
+
+        // 7) 엔티티 상태 최종 반영
+        // 경기 전체 스코어 증분 반영
+        Match match = matchRepository.getReferenceById(matchId);
+        match.addScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
+        // 쿼터 정보 업데이트
+        matchQuarter.updateScore(afterScores, afterConcedes);
+        matchQuarter.updateFormation(MatchFormation.fromName(requestDto.formation()));
+
+        // 8) 선수 스탯(Affiliation) 일괄 업데이트
+        applyAffiliationDeltas(playerStatsDeltaMap);
     }
 
     private void validateAffiliationIdsInSquad(List<MatchLineupCreateRequestDto> lineupRequestDto, List<MatchGoalCreateRequestDto> goalsInfoRequestDto, UUID clubId) {

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -65,14 +65,11 @@ public class MatchService {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
 
-        // 3) 매치 조회
-        Match match = matchRepository.findById(matchId)
+        // 3) 매치 조회 - 클럽 매치 여부 통합(4)
+        Match match = matchRepository.findByClub_ClubIdAndMatchId(clubId, matchId)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
 
-        // 4) 클럽 경기 여부
-        checkMatchBelongToClub(match.getClub().getClubId(), clubId);
-
-        // 5) 요청 라인업/골에 포함된 affiliationId가 클럽에 속해있는지 검증
+        // 5) 라인업/골에 포함된 affiliationId가 클럽 소속선수 ID인지 검증
         validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
 
         // 6) matchId 기준으로 "이미 출전한 선수" Set 확보 (matchCount 중복 증가 방지)
@@ -160,42 +157,7 @@ public class MatchService {
 
     @Transactional
     public void updateMatchQuarter(MatchQuarterUpdateRequestDto requestDto, UUID clubId, UUID matchId, Member member, Integer quarter) {
-        // [검증 로직]
-        // 1) 클럽 조회
-        checkClubIsExist(clubId);
-        // 2) 클럽 소속 여부 & 권한 체크(운영진 이삼만 쿼터생성 가능)
-        if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
-                clubId,
-                member.getMemberId(),
-                ClubJoinStatus.APPROVED,
-                List.of(ClubPlayerRole.OWNER, ClubPlayerRole.COACH))) {
-            throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
-        }
-        // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
-        Match match = findMatchById(matchId);
-        // 4) 클럽 경기 여부
-        checkMatchBelongToClub(match.getClub().getClubId(), clubId);
-        // 5) 라인업 선수 소속 여부 검증
-        validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
-        // 쿼터 조회
-        MatchQuarter matchQuarter = matchRepository.findByMatchQuarterId_MatchIdAndMatchQuarterId_Quarter(matchId, quarter)
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH_QUARTER));
-        // 기록 갱신이 필요한 선수들 ID
-        Set<UUID> updatedAffiliations = new HashSet<>();
-        // 수정전 라인업 포함 선수 ID 추가
-        addAffectedAffiliationIds(updatedAffiliations, matchQuarter.getLineup());
-        // 포메이션 & 실점 - Match 테이블 갱신
-        MatchFormation updateMatchFormation = requestDto.formation() != null ? MatchFormation.fromName(requestDto.formation()) : null;
-        matchQuarter.update(updateMatchFormation, requestDto.concededGoal());
-        // 기존 정보 제거
-        matchQuarter.clearQuarterData();
-        // 쿼터 라인업 - MatchLineup 테이블 추가
-        addQuarterLineup(updatedAffiliations, requestDto.lineup(), matchQuarter);
-        // 쿼터 (득점 & 도움) - MatchGoal 테이블 추가
-        addQuarterGoalAndAssist(requestDto.goalsInfo(), matchQuarter);
-        // (득점 & 실점) 계산 - Match 테이블 갱신
 
-        // (출전 경기수 & 득점 & 도움) 계산 - Affiliation 테이블 갱신
 
     }
 
@@ -321,17 +283,6 @@ public class MatchService {
     private void checkClubIsExist(UUID clubId) {
         if (!clubRepository.existsById(clubId)) {
             throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
-        }
-    }
-
-    private Match findMatchById(UUID matchId) {
-        return matchRepository.findById(matchId)
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
-    }
-
-    private void checkMatchBelongToClub(UUID matchClubId, UUID clubId) {
-        if (!matchClubId.equals(clubId)) {
-            throw new CustomException(ExceptionMessage.MATCH_NOT_BELONG_TO_CLUB);
         }
     }
 }

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -113,7 +113,7 @@ public class MatchService {
                 playerStatsDeltaMap.get(scorerId).addGoal();
             }
 
-            UUID assistId = goalInfo.assistPlayerAffiliationId();
+            UUID assistId = goalInfo.assistAffiliationId();
             if (assistId != null) {
                 if (!playerStatsDeltaMap.containsKey(assistId)) {
                     throw new CustomException(ExceptionMessage.PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD);
@@ -172,6 +172,9 @@ public class MatchService {
         }
 
         // TODO - fetch join 고려 -> MatchQuarter 정보
+        // 클럽 매치 조회
+        Match match = matchRepository.findByClub_ClubIdAndMatchId(clubId, matchId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
         // 매치 쿼터 조회
         MatchQuarter matchQuarter = matchRepository.findByMatchQuarterId_MatchIdAndMatchQuarterId_Quarter(matchId, quarter)
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH_QUARTER));
@@ -217,7 +220,8 @@ public class MatchService {
                 playerStatsDeltaMap.get(scorerId).minusGoal();
             }
 
-            UUID assistId = beforeGoal.getAssistPlayer().getAffiliationId();
+            MatchPlayerInfo assistPlayer = beforeGoal.getAssistPlayer();
+            UUID assistId = (assistPlayer != null) ? assistPlayer.getAffiliationId() : null;
             if (assistId != null) {
                 if (!playerStatsDeltaMap.containsKey(assistId)) {
                     playerStatsDeltaMap.put(assistId, new PlayerStatsDelta(0, 0, 0));
@@ -293,7 +297,7 @@ public class MatchService {
                 }
             }
 
-            UUID assistId = goalInfo.assistPlayerAffiliationId();
+            UUID assistId = goalInfo.assistAffiliationId();
             if (assistId != null) {
                 if (playerStatsDeltaMap.containsKey(assistId)) {
                     playerStatsDeltaMap.get(assistId).addAssist();
@@ -306,7 +310,6 @@ public class MatchService {
 
         // 7) 엔티티 상태 최종 반영
         // 경기 전체 스코어 증분 반영
-        Match match = matchRepository.getReferenceById(matchId);
         match.addScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
         // 쿼터 정보 업데이트
         matchQuarter.updateScore(afterScores, afterConcedes);
@@ -333,8 +336,8 @@ public class MatchService {
                 if (goalDto.scorerAffiliationId() != null) {
                     affiliationIdsToValidate.add(goalDto.scorerAffiliationId());
                 }
-                if (goalDto.assistPlayerAffiliationId() != null) {
-                    affiliationIdsToValidate.add(goalDto.assistPlayerAffiliationId());
+                if (goalDto.assistAffiliationId() != null) {
+                    affiliationIdsToValidate.add(goalDto.assistAffiliationId());
                 }
             }
         }

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -4,6 +4,8 @@ import com.project.Karman.domain.entity.*;
 import com.project.Karman.domain.enums.ClubJoinStatus;
 import com.project.Karman.domain.enums.ClubPlayerRole;
 import com.project.Karman.domain.enums.MatchFormation;
+import com.project.Karman.domain.vo.MatchScoreDelta;
+import com.project.Karman.domain.vo.PlayerStatsDelta;
 import com.project.Karman.dto.request.*;
 import com.project.Karman.dto.response.MatchListResponseDto;
 import com.project.Karman.dto.response.MatchResponseDto;
@@ -14,6 +16,8 @@ import com.project.Karman.repository.ClubRepository;
 import com.project.Karman.repository.MatchRepository;
 import com.project.Karman.service.mapper.MatchMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +27,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class MatchService {
 
+    private static final Logger log = LoggerFactory.getLogger(MatchService.class);
     private final ClubRepository clubRepository;
     private final MatchRepository matchRepository;
     private final AffiliationRepository affiliationRepository;
@@ -48,10 +53,10 @@ public class MatchService {
 
     @Transactional
     public void createMatchQuarter(MatchQuarterCreateRequestDto requestDto, UUID clubId, UUID matchId, Member member) {
-        // [검증 로직]
-        // 1) 클럽 조회
+        // 1) 클럽 존재
         checkClubIsExist(clubId);
-        // 2) 클럽 소속 여부 & 권한 체크(운영진 이상부터 생성가능)
+
+        // 2) 권한(운영진)
         if (!affiliationRepository.existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(
                 clubId,
                 member.getMemberId(),
@@ -60,30 +65,97 @@ public class MatchService {
             throw new CustomException(ExceptionMessage.PERMISSION_DENIED_MEMBER);
         }
 
-        // 3) 매치 조회 - 존재 여부 판단 + 영속성 컨텍스트 저장
-        Match match = findMatchById(matchId);
+        // 3) 매치 조회
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_MATCH));
+
         // 4) 클럽 경기 여부
         checkMatchBelongToClub(match.getClub().getClubId(), clubId);
-        // TODO - MVP 구현 후 A안 B안 속도 비교
-        // 5) 라인업 선수 소속 여부 검증 - A안
+
+        // 5) 요청 라인업/골에 포함된 affiliationId가 클럽에 속해있는지 검증
         validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
-        // [비즈니스 로직]
-        // 포메이션 변환
-        MatchFormation matchFormation = MatchFormation.fromName(requestDto.formation());
-        // 쿼터 생성
-        MatchQuarter matchQuarter = matchMapper.toMatchQuarterEntity(requestDto, match, matchFormation);
-        // 기록 갱신이 필요한 선수들 ID
-        Set<UUID> updatedAffiliations = new HashSet<>();
-        // 쿼터 라인업 - MatchLineup 테이블 추가
-        addQuarterLineup(updatedAffiliations, requestDto.lineup(), matchQuarter);
-        // 쿼터 (득점 & 도움) - MatchGoal 테이블 추가
-        addQuarterGoalAndAssist(requestDto.goalsInfo(), matchQuarter);
-        // 매치에 쿼터 추가
+
+        // 6) matchId 기준으로 "이미 출전한 선수" Set 확보 (matchCount 중복 증가 방지)
+        Set<UUID> playedAffiliationIds = matchRepository.findPlayedAffiliationIdsByMatchId(matchId);
+
+        // 7) 쿼터 생성
+        MatchQuarter matchQuarter = matchMapper.toMatchQuarterEntity(
+                requestDto, match, MatchFormation.fromName(requestDto.formation()));
+
+        // 8) 델타 준비
+        MatchScoreDelta matchScoreDelta = new MatchScoreDelta(requestDto.goalsInfo().size(), requestDto.concededGoal());
+        Map<UUID, PlayerStatsDelta> playerStatsDeltaMap = new HashMap<>();
+
+        // 9) 라인업 저장 + (matchCountDelta 계산)
+        for (MatchLineupCreateRequestDto playerInfo : requestDto.lineup()) {
+            MatchLineup matchLineup = matchMapper.toMatchLineupEntity(matchQuarter, playerInfo);
+            matchQuarter.addLineup(matchLineup);
+
+            UUID affiliationId = playerInfo.affiliationId();
+            if (affiliationId == null) continue;
+
+            // deltaMap 엔트리 확보
+            playerStatsDeltaMap.putIfAbsent(affiliationId, new PlayerStatsDelta(0, 0, 0));
+
+            // 해당 match에서 처음 출전이면 matchCount +1
+            if (!playedAffiliationIds.contains(affiliationId)) {
+                playerStatsDeltaMap.get(affiliationId).addMatchCount();
+                playedAffiliationIds.add(affiliationId); // 같은 요청에서 중복 방지
+            }
+        }
+
+        // 10) 득점/도움 저장 + (goal/assistDelta 계산)
+        for (MatchGoalCreateRequestDto goalInfo : requestDto.goalsInfo()) {
+            MatchGoal matchGoal = matchMapper.toMatchGoalEntity(matchQuarter, goalInfo);
+            matchQuarter.addScoredGoal(matchGoal);
+
+            UUID scorerId = goalInfo.scorerAffiliationId();
+            if (scorerId != null) {
+                if (!playerStatsDeltaMap.containsKey(scorerId)) {
+                    throw new CustomException(ExceptionMessage.PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD);
+                }
+                playerStatsDeltaMap.get(scorerId).addGoal();
+            }
+
+            UUID assistId = goalInfo.assistPlayerAffiliationId();
+            if (assistId != null) {
+                if (!playerStatsDeltaMap.containsKey(assistId)) {
+                    throw new CustomException(ExceptionMessage.PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD);
+                }
+                playerStatsDeltaMap.get(assistId).addAssist();
+            }
+        }
+
+        // 11) match에 쿼터 추가
         match.addMatchQuarter(matchQuarter);
-        // (득점 & 실점) 계산 - Match 테이블 갱신
-        calculateMatchScore(match);
-        // (출전 경기수 & 득점 & 도움) 계산 - Affiliation 테이블 갱신
-        calculateAffiliationStats(updatedAffiliations);
+
+        // 12) Match 스코어 증분 반영
+        match.updateScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
+
+        // 13) Affiliation 스탯 증분 반영 (한 번에 조회 후 더티체킹)
+        applyAffiliationDeltas(playerStatsDeltaMap);
+    }
+
+    private void applyAffiliationDeltas(Map<UUID, PlayerStatsDelta> deltaMap) {
+        if (deltaMap.isEmpty()) return;
+
+        List<UUID> deltaIds = new ArrayList<>(deltaMap.keySet());
+        List<Affiliation> affiliations = affiliationRepository.findAllById(deltaIds);
+
+        Map<UUID, Affiliation> affiliationMap = new HashMap<>();
+        for (Affiliation affiliation : affiliations) {
+            affiliationMap.put(affiliation.getAffiliationId(), affiliation);
+        }
+
+        for (Map.Entry<UUID, PlayerStatsDelta> entry : deltaMap.entrySet()) {
+            UUID affiliationId = entry.getKey();
+            PlayerStatsDelta delta = entry.getValue();
+
+            Affiliation affiliation = affiliationMap.get(affiliationId);
+            if (affiliation == null) continue;
+
+            affiliation.applyDelta(delta);
+        }
     }
 
     @Transactional
@@ -122,14 +194,34 @@ public class MatchService {
         // 쿼터 (득점 & 도움) - MatchGoal 테이블 추가
         addQuarterGoalAndAssist(requestDto.goalsInfo(), matchQuarter);
         // (득점 & 실점) 계산 - Match 테이블 갱신
-        calculateMatchScore(match);
+
         // (출전 경기수 & 득점 & 도움) 계산 - Affiliation 테이블 갱신
-        calculateAffiliationStats(updatedAffiliations);
+
     }
 
     private void validateAffiliationIdsInSquad(List<MatchLineupCreateRequestDto> lineupRequestDto, List<MatchGoalCreateRequestDto> goalsInfoRequestDto, UUID clubId) {
         // 입력받은 affiliationId 목록
-        Set<UUID> affiliationIdsToValidate = getAffiliationIdsFromDto(lineupRequestDto, goalsInfoRequestDto);
+        Set<UUID> affiliationIdsToValidate = new HashSet<>();
+
+        // 라인업에서 수집
+        for (MatchLineupCreateRequestDto lineupDto : lineupRequestDto) {
+            if (lineupDto.affiliationId() != null) {
+                affiliationIdsToValidate.add(lineupDto.affiliationId());
+            }
+        }
+
+        // 득점/어시스트 정보에서 수집
+        if (goalsInfoRequestDto != null) {
+            for (MatchGoalCreateRequestDto goalDto : goalsInfoRequestDto) {
+                if (goalDto.scorerAffiliationId() != null) {
+                    affiliationIdsToValidate.add(goalDto.scorerAffiliationId());
+                }
+                if (goalDto.assistPlayerAffiliationId() != null) {
+                    affiliationIdsToValidate.add(goalDto.assistPlayerAffiliationId());
+                }
+            }
+        }
+
         // 검증
         if (!affiliationIdsToValidate.isEmpty()) {
             // 실존하는 affiliationId 객체만 리스트로 반환
@@ -142,38 +234,20 @@ public class MatchService {
         }
     }
 
-    private Set<UUID> getAffiliationIdsFromDto(List<MatchLineupCreateRequestDto> lineupRequestDto, List<MatchGoalCreateRequestDto> goalsInfoRequestDto) {
-        Set<UUID> affiliationIdsToValidate = new HashSet<>();
-        // 라인업에서 수집
-        for (MatchLineupCreateRequestDto lineupDto : lineupRequestDto) {
-            if (lineupDto.affiliationId() != null) {
-                affiliationIdsToValidate.add(lineupDto.affiliationId());
-            }
-        }
-        // 득점/어시스트 정보에서 수집
-        if (goalsInfoRequestDto != null) {
-            for (MatchGoalCreateRequestDto goalDto : goalsInfoRequestDto) {
-                if (goalDto.scorerAffiliationId() != null) {
-                    affiliationIdsToValidate.add(goalDto.scorerAffiliationId());
-                }
-                if (goalDto.assistPlayerAffiliationId() != null) {
-                    affiliationIdsToValidate.add(goalDto.assistPlayerAffiliationId());
-                }
-            }
-        }
-        return affiliationIdsToValidate;
+    private void calculateMatchScore(Match match, MatchScoreDelta matchScoreDelta) {
+        log.info("매치 점수 계산합니다잉");
+        // 업데이트 스코어
+        match.updateScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
     }
 
-    private void calculateMatchScore(Match match) {
-        // 득점
-        Long updatedScoredGoal = matchRepository.countGoalsByMatchId(match.getMatchId());
-        // 실점
-        Long updatedConcededGoal = matchRepository.countConcededGoalsByMatchId(match.getMatchId());
-        // 업데이트 스코어
-        match.updateScore(updatedScoredGoal, updatedConcededGoal);
+    private void calculateAffiliationStats(Set<UUID> updateAffiliationIds) {
+
+        log.info("#### 선수 스탯 업데이트 시작합니다잉####");
+
     }
 
     private void addQuarterLineup(Set<UUID> updatedAffiliations, List<MatchLineupCreateRequestDto> lineup, MatchQuarter matchQuarter) {
+        log.info("#####---쿼터 라인업 생성 및 추가---#####");
         for (MatchLineupCreateRequestDto lineupDto : lineup) {
             // 출전선수 정보 생성
             MatchLineup playerInLineup = matchMapper.toMatchLineupEntity(matchQuarter, lineupDto);
@@ -186,25 +260,11 @@ public class MatchService {
     }
 
     private void addQuarterGoalAndAssist(List<MatchGoalCreateRequestDto> goalsInfo, MatchQuarter matchQuarter) {
-
+        log.info("#####---쿼터 골/도움 기록 생성 및 추가---#####");
         for (MatchGoalCreateRequestDto goalDto : goalsInfo) {
             // 득점 정보 객체 생성 및 저장
             MatchGoal scoreInfo = matchMapper.toMatchGoalEntity(matchQuarter, goalDto);
             matchQuarter.addScoredGoal(scoreInfo);
-        }
-    }
-
-    private void calculateAffiliationStats(Set<UUID> updateAffiliationIds) {
-        for (UUID updateAffiliationId : updateAffiliationIds) {
-            Affiliation updatePlayer = affiliationRepository.findById(updateAffiliationId)
-                    .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
-
-            Long updatedMatches = matchRepository.countPlayedMatchesByAffiliationId(updateAffiliationId);
-            Long updatedGoals = matchRepository.countGoalsByAffiliationId(updateAffiliationId);
-            Long updatedAssists = matchRepository.countAssistsByAffiliationId(updateAffiliationId);
-            updatePlayer.updateMatchCount(updatedMatches);
-            updatePlayer.updateGoal(updatedGoals);
-            updatePlayer.updateAssist(updatedAssists);
         }
     }
 

--- a/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/MatchMapper.java
@@ -25,14 +25,13 @@ public class MatchMapper {
         );
     }
 
-    public MatchQuarter toMatchQuarterEntity(MatchQuarterCreateRequestDto requestDto, Match match, MatchFormation matchFormation) {
+    public MatchQuarter toMatchQuarterEntity(Match match, Integer quarter, MatchFormation matchFormation) {
 
         return MatchQuarter.of(
                 match.getMatchId(),
-                requestDto.quarter(),
+                quarter,
                 match,
-                matchFormation,
-                requestDto.concededGoal()
+                matchFormation
         );
     }
 


### PR DESCRIPTION
## 📌 개요

쿼터 생성/수정 API에서 발생하던 **COUNT 기반 전체 재계산 구조를 제거**하고,  
**delta(증분) 기반 갱신 방식으로 전환**하여 쓰기 API 성능을 개선합니다.

또한, 이 과정에서 함께 드러난 **Match 조회 조건 불일치**,  
**쿼터 생성 시 득/실점 반영 누락 버그**를 함께 수정했습니다.

> 본 PR은 기능 추가가 아닌  
> **성능 개선 + 정합성 보완 + 조회 로직 정리**를 목적으로 합니다.

---

## 🔧 변경 사항 요약

### 1️⃣ [perf] 쿼터 생성 API 성능 개선 v1

- **기존**
  - 쿼터 생성 시 Match / Affiliation 스탯을 **COUNT 쿼리로 전체 재계산**
- **변경**
  - 득점/실점/출전/도움 **변경분만 delta 기반으로 증분 반영**
- **적용**
  - `MatchScoreDelta`, `PlayerStatsDelta` VO 도입
  - Match / Affiliation 누적 컬럼을 증분 갱신 방식으로 전환

---

### 2️⃣ [perf] 쿼터 수정 API 성능 개선 v1

- **기존**
  - 수정 시 기존 기록 삭제 → 재삽입 → 전체 재집계
- **변경**
  - 수정 전/후 diff 계산 후 **변경된 선수만 delta 반영**
- **특징**
  - 현재 쿼터를 제외한 다른 쿼터 출전 여부를 단일 쿼리로 조회
  - 실제 경기 출전 상태가 변한 경우에만 matchCount ±1 적용

---

### 3️⃣ [refactor] Match 조회 로직 clubId + matchId 기준으로 통합

- **기존**
  - Match 조회 시 API별로 조건이 달라 혼란 가능성 존재
- **변경**
  - 모든 Match 조회를 `clubId + matchId` 기준으로 통합
- **효과**
  - 권한 검증 로직 단순화
  - 도메인 규칙 명확화 (클럽 소속 Match만 접근 가능)

---

### 4️⃣ [fix] 쿼터 생성 시 MatchQuarter 득/실점 반영 누락 수정

- **문제**
  - 쿼터 생성 시 MatchQuarter 엔티티의 득/실점 값이 누락되는 케이스 존재
- **조치**
  - 쿼터 생성 시점에 득점/실점 값을 명시적으로 반영하도록 수정
- **효과**
  - 쿼터/매치 간 점수 불일치 문제 해결

---

## 📈 성능 개선 결과

> **동일 조건(Postman Runner, 53회 반복 요청 기준)**

### 🔹 쿼터 생성 API (POST)

#### ▫️ 개선 전 (V0)
[쿼터 생성 API v0 성능]
<img width="884" height="336" alt="스크린샷 2026-01-20 오후 5 18 39" src="https://github.com/user-attachments/assets/f95a7059-873b-483d-9457-9154a065e8d9" />


- 평균 응답 시간: **약 2.7s**

#### ▫️ 개선 후 (V1)
[쿼터 생성 API v1 성능]
<img width="888" height="340" alt="스크린샷 2026-01-20 오후 5 18 07" src="https://github.com/user-attachments/assets/2e3fdc45-e755-4294-84ae-0d91b9f57e92" />



- 평균 응답 시간: **약 1.1s**
- ➡️ **약 58% 성능 개선**

---

### 🔹 쿼터 수정 API (PATCH)

#### ▫️ 개선 전 (V0)
[쿼터 수정 API 
<img width="884" height="369" alt="스크린샷 2026-01-20 오후 5 17 46" src="https://github.com/user-attachments/assets/d9db255c-033a-492f-892e-4c1f524a21ac" />
v0 성능]


- 평균 응답 시간: **약 3.8s**

#### ▫️ 개선 후 (V1)
[쿼터 수정 API v1 성능]
<img width="906" height="379" alt="스크린샷 2026-01-20 오후 5 16 53" src="https://github.com/user-attachments/assets/431848d0-95fd-4c7d-a1b0-e6750a427ac0" />



- 평균 응답 시간: **약 1.8s**
- ➡️ **약 52% 성능 개선**

---

### 📌 정리

- 모든 성능 측정은 **동일 요청 / 동일 반복 횟수(53회)** 기준으로 수행
- COUNT 기반 전체 재계산 제거 후  
  👉 **쓰기 API의 평균 응답 시간이 절반 수준으로 감소**

---

### ✨ 한 줄 요약 (리뷰어용)

> COUNT 재계산 구조를 제거하고, 쿼터 생성/수정을 delta 기반 증분 업데이트로 전환한 성능 개선 PR입니다.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts write paths to incremental updates and standardizes match retrieval, improving performance and data consistency.
> 
> - Introduces `PlayerStatsDelta` and `MatchScoreDelta` to incrementally update `Affiliation` and `Match` stats instead of COUNT-based recompute
> - Refactors `MatchService` quarter create/update to compute/apply deltas, avoid double-counting across quarters, and batch-apply affiliation changes
> - Entities updated: `Match.addScore(...)`, `MatchQuarter.updateScore(...)`/`updateFormation(...)`, `Affiliation.applyDelta(...)`
> - Repository changes: add `findByClub_ClubIdAndMatchId`/`existsByClub_ClubIdAndMatchId`; new queries to fetch played affiliation IDs (overall and excluding a quarter) for diffing
> - Validation & errors: enforce scorer/assist must be in lineup; add `PLAYER_NOT_IN_LINEUP_FOR_GOAL_RECORD`
> - DTO tweak: rename assist fields in `MatchGoalCreateRequestDto` to `assistName`/`assistAffiliationId`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386012ddbedbc12f0d4dc873f2f35c3b4d85d335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->