### PR TITLE
[#21] 쿼터 수정 시 Match/MatchQuarter 스코어 미반영 문제 해결

### DIFF
--- a/src/main/java/com/project/Karman/repository/MatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchRepository.java
@@ -81,7 +81,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
             @Param("lose") MatchResult lose);
 
     // 쿼터 모든 골 기록 삭제
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             DELETE FROM MatchGoal mg
             WHERE mg.matchQuarter.matchQuarterId.matchId = :matchId
@@ -92,7 +92,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
             @Param("quarter") Integer quarter);
 
     // 쿼터 모든 라인업 삭제
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             DELETE FROM MatchLineup ml
             WHERE ml.matchQuarter.matchQuarterId.matchId = :matchId

--- a/src/main/java/com/project/Karman/service/MatchService.java
+++ b/src/main/java/com/project/Karman/service/MatchService.java
@@ -177,6 +177,11 @@ public class MatchService {
 
         // 매치 스코어 증분 데이터
         MatchScoreDelta matchScoreDelta = new MatchScoreDelta(afterScores - beforeScores, afterConcedes - beforeConcedes);
+        // 경기 전체 스코어 업데이트
+        match.addScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
+        // 쿼터 정보 업데이트
+        matchQuarter.updateScore(afterScores, afterConcedes);
+        matchQuarter.updateFormation(MatchFormation.fromName(requestDto.formation()));
 
         // update 라인업 유효성 검사
         validateAffiliationIdsInSquad(requestDto.lineup(), requestDto.goalsInfo(), clubId);
@@ -302,14 +307,7 @@ public class MatchService {
         matchQuarterBatchRepository.batchInsertMatchLineup(newLineupBatchDtoList);
         matchQuarterBatchRepository.batchInsertMatchGoal(newGoalsBatchDtoList);
 
-        // 7) 엔티티 상태 최종 반영
-        // 경기 전체 스코어 증분 반영
-        match.addScore(matchScoreDelta.getScoreGoal(), matchScoreDelta.getConcedeGoal());
-        // 쿼터 정보 업데이트
-        matchQuarter.updateScore(afterScores, afterConcedes);
-        matchQuarter.updateFormation(MatchFormation.fromName(requestDto.formation()));
-
-        // 8) 선수 스탯(Affiliation) 일괄 업데이트 (Batch Update)
+        // ✅ Batch Update: 선수 스탯(Affiliation) 일괄 업데이트
         applyAffiliationDeltas(playerStatsDeltaMap);
     }
 


### PR DESCRIPTION
## 🔴 문제 상황

> 성능 개선(V2) 로직 적용 후, 쿼터 생성 API는 정상적으로 동작했으나, **쿼터 수정 API** 호출 시 일부 상위 집계 데이터가 갱신되지 않는 정합성 문제가 발견되었습니다.

* **정상 동작:** 개별 선수의 스탯(`Affiliation`)과 쿼터 내 득점 수(`MatchQuarter`)는 정상적으로 반영됨.
* **오류 현상:** 반면, 쿼터의 실점 정보와 부모 엔티티인 **경기 전체 스코어(`Match` 득점/실점)**는 업데이트되지 않고 이전 상태로 유지됨.
* **결과:** 상세 기록(누가 골을 넣었는지)은 존재하나, 경기판의 종합 점수는 갱신되지 않는 **데이터 불일치(Inconsistency)** 발생.

## 🔍 원인 분석

> **Hibernate의 쓰기 지연(Write-Behind)** 저장소와 **Bulk 연산의 영속성 컨텍스트 초기화(`clear`)** 시점이 충돌하여 발생한 문제입니다.

1. **Hibernate의 동작 특성:**
* JPA(Hibernate)는 트랜잭션 커밋 시점까지 쿼리를 모았다가 최적화된 순서로 실행(쓰기 지연)합니다. 즉, 엔티티의 수정(`match.update...`)은 즉시 DB에 반영되지 않고 영속성 컨텍스트 메모리에 **Dirty 상태**로 남아있게 됩니다.


2. **Bulk Delete의 부작용:**
* 로직 중간에 실행된 Bulk Delete 메서드(`deleteLineups...`)에는 `@Modifying(clearAutomatically = true)` 옵션이 설정되어 있었습니다.
* 이 쿼리가 실행된 직후 **영속성 컨텍스트가 강제로 초기화(Clear)** 되었습니다.


3. **결과적 데이터 유실:**
* `Match`와 `MatchQuarter`의 변경 감지(Dirty Checking)가 수행되어 Update 쿼리가 나가야 했으나, 그 전에 `clear`가 실행되면서 **메모리에 있던 변경 사항이 증발**해버렸습니다.
* 또한, `@Modifying` 쿼리 실행 전 Flush가 기본적으로 보장되지 않아(테이블 연관성 미감지 등), 변경 사항이 Delete 이후 `clear` 시점까지 DB에 반영되지 않은 것이 핵심 원인이었습니다.



## 🛠 해결 방법

> 데이터 정합성을 보장하기 위해 **로직의 순서**와 **Flush 타이밍**을 제어했습니다.

**1. 로직 재배치 (Reordering)**

* 엔티티 상태 변경(Update) 코드를 Bulk Delete **실행 이전**으로 이동하여, 논리적으로 "데이터 수정 → 정리(Delete) → 생성(Insert)"의 흐름을 확립했습니다.

**2. 강제 Flush 적용 (Force Flush)**

* Bulk Delete 메서드에 `@Modifying(flushAutomatically = true)` 옵션을 추가했습니다.
* 이로 인해 Hibernate의 최적화 판단(Flush 생략)을 무시하고, **Delete 쿼리 실행 직전에 무조건 영속성 컨텍스트의 변경 사항을 DB에 반영(Flush)** 하도록 강제하여 정합성을 확보했습니다.