### PR TITLE
[#22] 선수 기록 이관 API 추가 및 가입 승인 흐름에 맞춘 이관 방식 수정

### DIFF
--- a/src/main/java/com/project/Karman/controller/ClubController.java
+++ b/src/main/java/com/project/Karman/controller/ClubController.java
@@ -163,4 +163,14 @@ public class ClubController {
                 .status(GET_CLUB_MEMBERS.getHttpStatus())
                 .body(ApiResponse.success(GET_CLUB_MEMBERS.getMessage(), clubMemberResponseDto));
     }
+
+    @PostMapping("/{club_id}/players/transfers")
+    public ResponseEntity<ApiResponse<Void>> transferAffiliationRecord(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                       @PathVariable(value = "club_id") UUID clubId,
+                                                                       @Valid @RequestBody TransferPlayerRecordRequestDto requestDto) {
+        clubService.transferPlayerRecord(userDetails.getMember(), clubId, requestDto);
+        return ResponseEntity
+                .status(TRANSFER_PLAYER_RECORD.getHttpStatus())
+                .body(ApiResponse.success(TRANSFER_PLAYER_RECORD.getMessage()));
+    }
 }

--- a/src/main/java/com/project/Karman/controller/ClubController.java
+++ b/src/main/java/com/project/Karman/controller/ClubController.java
@@ -154,4 +154,13 @@ public class ClubController {
                 .status(GET_CLUB_JOIN_REQUESTS.getHttpStatus())
                 .body(ApiResponse.success(GET_CLUB_JOIN_REQUESTS.getMessage(), clubJoinRequestListResponseDto));
     }
+
+    @GetMapping("/{club_id}/members")
+    public ResponseEntity<ApiResponse<ClubMembersListResponseDto>> getClubMembers(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                  @PathVariable(value = "club_id") UUID clubId) {
+        ClubMembersListResponseDto clubMemberResponseDto = clubService.getClubMembers(userDetails.getMember(), clubId);
+        return ResponseEntity
+                .status(GET_CLUB_MEMBERS.getHttpStatus())
+                .body(ApiResponse.success(GET_CLUB_MEMBERS.getMessage(), clubMemberResponseDto));
+    }
 }

--- a/src/main/java/com/project/Karman/domain/entity/Affiliation.java
+++ b/src/main/java/com/project/Karman/domain/entity/Affiliation.java
@@ -93,9 +93,8 @@ public class Affiliation extends BaseEntity {
         this.backNumber = updatedBackNumber == null ? this.backNumber : updatedBackNumber;
     }
 
-    public void applyDelta(PlayerStatsDelta delta) {
-        this.matchCount += delta.getMatchCount();
-        this.goal += delta.getGoal();
-        this.assist += delta.getAssist();
+    public void transferAffiliationInfo(String playerName, Member member) {
+        this.playerName = playerName;
+        this.member = member;
     }
 }

--- a/src/main/java/com/project/Karman/dto/request/TransferPlayerRecordRequestDto.java
+++ b/src/main/java/com/project/Karman/dto/request/TransferPlayerRecordRequestDto.java
@@ -1,0 +1,14 @@
+package com.project.Karman.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record TransferPlayerRecordRequestDto(
+        @NotNull(message = "이관할 멤버의 ID는 필수 입력 값 입니다.")
+        UUID memberId,
+
+        @NotNull(message = "이관될 선수의 ID는 필수 입력 값 입니다.")
+        UUID affiliationId
+) {
+}

--- a/src/main/java/com/project/Karman/dto/response/ClubJoinRequestResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/ClubJoinRequestResponseDto.java
@@ -8,13 +8,15 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PRIVATE)
 public record ClubJoinRequestResponseDto(
         UUID affiliationId,
+        UUID memberId,
         String name
 ) {
 
-    public static ClubJoinRequestResponseDto of(UUID affiliationId, String name) {
+    public static ClubJoinRequestResponseDto of(UUID affiliationId, UUID memberId, String name) {
 
         return ClubJoinRequestResponseDto.builder()
                 .affiliationId(affiliationId)
+                .memberId(memberId)
                 .name(name)
                 .build();
     }

--- a/src/main/java/com/project/Karman/dto/response/ClubMemberResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/ClubMemberResponseDto.java
@@ -1,0 +1,23 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ClubMemberResponseDto(
+        UUID affiliationId,
+        String name,
+        Integer backNumber
+) {
+
+    public static ClubMemberResponseDto of(UUID affiliationId, String name, Integer backNumber) {
+
+        return ClubMemberResponseDto.builder()
+                .affiliationId(affiliationId)
+                .name(name)
+                .backNumber(backNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/dto/response/ClubMemberResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/ClubMemberResponseDto.java
@@ -8,14 +8,16 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PRIVATE)
 public record ClubMemberResponseDto(
         UUID affiliationId,
+        UUID memberId,
         String name,
         Integer backNumber
 ) {
 
-    public static ClubMemberResponseDto of(UUID affiliationId, String name, Integer backNumber) {
+    public static ClubMemberResponseDto of(UUID affiliationId, UUID memberId, String name, Integer backNumber) {
 
         return ClubMemberResponseDto.builder()
                 .affiliationId(affiliationId)
+                .memberId(memberId)
                 .name(name)
                 .backNumber(backNumber)
                 .build();

--- a/src/main/java/com/project/Karman/dto/response/ClubMembersListResponseDto.java
+++ b/src/main/java/com/project/Karman/dto/response/ClubMembersListResponseDto.java
@@ -1,0 +1,19 @@
+package com.project.Karman.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ClubMembersListResponseDto(
+        List<ClubMemberResponseDto> clubMembers
+) {
+
+    public static ClubMembersListResponseDto of(List<ClubMemberResponseDto> clubMembers) {
+
+        return ClubMembersListResponseDto.builder()
+                .clubMembers(clubMembers)
+                .build();
+    }
+}

--- a/src/main/java/com/project/Karman/exception/ExceptionMessage.java
+++ b/src/main/java/com/project/Karman/exception/ExceptionMessage.java
@@ -17,9 +17,11 @@ public enum ExceptionMessage {
     OWNER_CAN_NOT_WITHDRAW_CLUB(HttpStatus.BAD_REQUEST, "구단주는 클럽을 탈퇴할 수 없습니다.", 400), // 탈퇴하면 클럽 삭제 되도록 수정
     ALREADY_JOINED_PLAYER(HttpStatus.BAD_REQUEST, "이미 가입된 선수입니다.", 400),
     NOT_ALLOWED_OWNER_ROLE(HttpStatus.BAD_REQUEST, "구단주 권한은 허용되지 않습니다.", 400),
-    PLAYER_HAS_MEMBER_ID(HttpStatus.BAD_REQUEST,"멤버 ID가 존재하는 선수 데이터 입니다.",400),
+    PLAYER_HAS_MEMBER_ID(HttpStatus.BAD_REQUEST, "멤버 ID가 존재하는 선수 데이터 입니다.", 400),
     NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "찾을 수 없는 클럽(팀) 입니다.", 404),
     NOT_FOUND_PLAYER_IN_CLUB(HttpStatus.NOT_FOUND, "클럽(팀)에 소속되지 않은 선수 입니다.", 404),
+    NOT_FOUND_SOURCE_PLAYER(HttpStatus.NOT_FOUND, "찾을 수 없는 이관대상 선수 입니다.", 404),
+    NOT_FOUND_PLAYER_TO_CLUB(HttpStatus.NOT_FOUND, "찾을 수 없는 가입요청 선수 입니다.", 404),
     PERMISSION_DENIED_USER_GET_CLUB(HttpStatus.FORBIDDEN, "클럽 정보 조회 권한이 없는 유저입니다.", 403),
     PERMISSION_DENIED_USER_UPDATE_CLUB(HttpStatus.FORBIDDEN, "클럽 수정 권한이 없는 유저입니다.", 403),
 

--- a/src/main/java/com/project/Karman/exception/ExceptionMessage.java
+++ b/src/main/java/com/project/Karman/exception/ExceptionMessage.java
@@ -17,6 +17,7 @@ public enum ExceptionMessage {
     OWNER_CAN_NOT_WITHDRAW_CLUB(HttpStatus.BAD_REQUEST, "구단주는 클럽을 탈퇴할 수 없습니다.", 400), // 탈퇴하면 클럽 삭제 되도록 수정
     ALREADY_JOINED_PLAYER(HttpStatus.BAD_REQUEST, "이미 가입된 선수입니다.", 400),
     NOT_ALLOWED_OWNER_ROLE(HttpStatus.BAD_REQUEST, "구단주 권한은 허용되지 않습니다.", 400),
+    PLAYER_HAS_MEMBER_ID(HttpStatus.BAD_REQUEST,"멤버 ID가 존재하는 선수 데이터 입니다.",400),
     NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "찾을 수 없는 클럽(팀) 입니다.", 404),
     NOT_FOUND_PLAYER_IN_CLUB(HttpStatus.NOT_FOUND, "클럽(팀)에 소속되지 않은 선수 입니다.", 404),
     PERMISSION_DENIED_USER_GET_CLUB(HttpStatus.FORBIDDEN, "클럽 정보 조회 권한이 없는 유저입니다.", 403),

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -27,6 +27,7 @@ public enum SuccessMessage {
     GET_CLUB_STATICS_RECORDS(HttpStatus.OK, "클럽 통계 기록 조회", 200),
     GET_CLUB_JOIN_REQUESTS(HttpStatus.OK, "가입요청 선수목록 조회", 200),
     GET_CLUB_MEMBERS(HttpStatus.OK, "클럽 멤버 목록 조회", 200),
+    TRANSFER_PLAYER_RECORD(HttpStatus.OK, "선수기록 이관 완료", 200),
 
     // 매치 서비스
     CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),

--- a/src/main/java/com/project/Karman/exception/SuccessMessage.java
+++ b/src/main/java/com/project/Karman/exception/SuccessMessage.java
@@ -26,6 +26,7 @@ public enum SuccessMessage {
     GET_PLAYERS_INFO_IN_CLUB(HttpStatus.OK, "클럽 소속선수 전체기록 조회", 200),
     GET_CLUB_STATICS_RECORDS(HttpStatus.OK, "클럽 통계 기록 조회", 200),
     GET_CLUB_JOIN_REQUESTS(HttpStatus.OK, "가입요청 선수목록 조회", 200),
+    GET_CLUB_MEMBERS(HttpStatus.OK, "클럽 멤버 목록 조회", 200),
 
     // 매치 서비스
     CRATE_MATCH(HttpStatus.OK, "신규 매치등록 완료", 200),

--- a/src/main/java/com/project/Karman/repository/AffiliationRepository.java
+++ b/src/main/java/com/project/Karman/repository/AffiliationRepository.java
@@ -18,6 +18,8 @@ public interface AffiliationRepository extends JpaRepository<Affiliation, UUID> 
 
     List<Affiliation> findAllByClub_ClubIdAndJoinStatusOrderByBackNumberAsc(UUID clubId, ClubJoinStatus joinStatus);
 
+    List<Affiliation> findAllByClub_ClubIdAndMember_MemberIdIsNotNull(UUID clubId);
+
     Optional<Affiliation> findByClub_ClubIdAndMember_MemberId(UUID clubId, UUID memberId);
 
     Boolean existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(UUID clubId, UUID memberId, ClubJoinStatus joinStatus);

--- a/src/main/java/com/project/Karman/repository/AffiliationRepository.java
+++ b/src/main/java/com/project/Karman/repository/AffiliationRepository.java
@@ -22,6 +22,8 @@ public interface AffiliationRepository extends JpaRepository<Affiliation, UUID> 
 
     Optional<Affiliation> findByClub_ClubIdAndMember_MemberId(UUID clubId, UUID memberId);
 
+    Optional<Affiliation> findByAffiliationIdAndClub_ClubId(UUID affiliationId, UUID clubId);
+
     Boolean existsByClub_ClubIdAndMember_MemberIdAndJoinStatus(UUID clubId, UUID memberId, ClubJoinStatus joinStatus);
 
     boolean existsByClub_ClubIdAndMember_MemberIdAndJoinStatusAndPlayerRoleIn(

--- a/src/main/java/com/project/Karman/repository/MatchQuarterBatchRepository.java
+++ b/src/main/java/com/project/Karman/repository/MatchQuarterBatchRepository.java
@@ -88,14 +88,17 @@ public class MatchQuarterBatchRepository {
                     scorer_name,
                     scorer_affiliation_id,
                     assist_name,
-                    assist_affiliation_id
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    assist_affiliation_id,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
 
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
                 MatchGoalBatchDto goal = goals.get(i);
+                Timestamp now = Timestamp.valueOf(LocalDateTime.now());
 
                 // 1. PK
                 ps.setObject(1, goal.matchGoalId());
@@ -116,6 +119,9 @@ public class MatchQuarterBatchRepository {
                     ps.setObject(6, null);
                     ps.setObject(7, null);
                 }
+                // 5. BaseEntity 필드
+                ps.setTimestamp(8, now);
+                ps.setTimestamp(9, now);
             }
 
             @Override

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -244,6 +244,27 @@ public class ClubService {
         return affiliationMapper.toClubMemberListDto(clubMembers);
     }
 
+    @Transactional
+    public void transferPlayerRecord(Member member, UUID clubId, TransferPlayerRecordRequestDto requestDto) {
+
+        if (!clubRepository.existsById(clubId)) {
+            throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
+        }
+
+        validateMemberIsManagement(clubId, member.getMemberId());
+
+        Affiliation targetAffiliation = affiliationRepository.findByClub_ClubIdAndMember_MemberId(clubId, requestDto.memberId())
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
+
+        Affiliation sourceAffiliation = affiliationRepository.findById(requestDto.affiliationId())
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
+
+        Member targetMember = memberRepository.getReferenceById(requestDto.memberId());
+        sourceAffiliation.transferAffiliationInfo(targetAffiliation.getPlayerName(), targetMember);
+        sourceAffiliation.updatePlayerInfo(targetAffiliation.getPlayerPosition(), targetAffiliation.getBackNumber());
+        affiliationRepository.delete(targetAffiliation);
+    }
+
     // 클럽 상세조회
     private Club findClubById(UUID clubId) {
         return clubRepository.findById(clubId)

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -259,6 +259,10 @@ public class ClubService {
         Affiliation sourceAffiliation = affiliationRepository.findById(requestDto.affiliationId())
                 .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
 
+        if(sourceAffiliation.getMember() != null) {
+            throw  new CustomException(ExceptionMessage.PLAYER_HAS_MEMBER_ID);
+        }
+
         Member targetMember = memberRepository.getReferenceById(requestDto.memberId());
         sourceAffiliation.transferAffiliationInfo(targetAffiliation.getPlayerName(), targetMember);
         sourceAffiliation.updatePlayerInfo(targetAffiliation.getPlayerPosition(), targetAffiliation.getBackNumber());

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -265,7 +265,6 @@ public class ClubService {
 
         Member targetMember = memberRepository.getReferenceById(requestDto.memberId());
         sourceAffiliation.transferAffiliationInfo(targetAffiliation.getPlayerName(), targetMember);
-        sourceAffiliation.updatePlayerInfo(targetAffiliation.getPlayerPosition(), targetAffiliation.getBackNumber());
         affiliationRepository.delete(targetAffiliation);
     }
 

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -233,6 +233,17 @@ public class ClubService {
         return affiliationMapper.toClubJoinRequestListDto(clubId, clubJoinRequestAffiliations);
     }
 
+    @Transactional(readOnly = true)
+    public ClubMembersListResponseDto getClubMembers(Member member, UUID clubId) {
+        // 클럽 조회
+        if (!clubRepository.existsById(clubId)) {
+            throw new CustomException(ExceptionMessage.NOT_FOUND_CLUB);
+        }
+        // 클럽 소속 멤버 조회
+        List<Affiliation> clubMembers = affiliationRepository.findAllByClub_ClubIdAndMember_MemberIdIsNotNull(clubId);
+        return affiliationMapper.toClubMemberListDto(clubMembers);
+    }
+
     // 클럽 상세조회
     private Club findClubById(UUID clubId) {
         return clubRepository.findById(clubId)

--- a/src/main/java/com/project/Karman/service/ClubService.java
+++ b/src/main/java/com/project/Karman/service/ClubService.java
@@ -254,13 +254,13 @@ public class ClubService {
         validateMemberIsManagement(clubId, member.getMemberId());
 
         Affiliation targetAffiliation = affiliationRepository.findByClub_ClubIdAndMember_MemberId(clubId, requestDto.memberId())
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_TO_CLUB));
 
-        Affiliation sourceAffiliation = affiliationRepository.findById(requestDto.affiliationId())
-                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PLAYER_IN_CLUB));
+        Affiliation sourceAffiliation = affiliationRepository.findByAffiliationIdAndClub_ClubId(requestDto.affiliationId(), clubId)
+                .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_SOURCE_PLAYER));
 
-        if(sourceAffiliation.getMember() != null) {
-            throw  new CustomException(ExceptionMessage.PLAYER_HAS_MEMBER_ID);
+        if (sourceAffiliation.getMember() != null) {
+            throw new CustomException(ExceptionMessage.PLAYER_HAS_MEMBER_ID);
         }
 
         Member targetMember = memberRepository.getReferenceById(requestDto.memberId());

--- a/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
@@ -109,4 +109,23 @@ public class AffiliationMapper {
                 clubJoinRequestResponseDtoList
         );
     }
+
+    public ClubMemberResponseDto toClubMemberDto(Affiliation affiliation) {
+
+        return ClubMemberResponseDto.of(
+                affiliation.getAffiliationId(),
+                affiliation.getPlayerName(),
+                affiliation.getBackNumber()
+        );
+    }
+
+    public ClubMembersListResponseDto toClubMemberListDto(List<Affiliation> clubMembers) {
+        List<ClubMemberResponseDto> clubMemberResponseDtoList = clubMembers.stream()
+                .map(this::toClubMemberDto)
+                .toList();
+
+        return ClubMembersListResponseDto.of(
+                clubMemberResponseDtoList
+        );
+    }
 }

--- a/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
@@ -94,6 +94,7 @@ public class AffiliationMapper {
 
         return ClubJoinRequestResponseDto.of(
                 affiliation.getAffiliationId(),
+                affiliation.getMember().getMemberId(),
                 affiliation.getPlayerName()
         );
     }

--- a/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
+++ b/src/main/java/com/project/Karman/service/mapper/AffiliationMapper.java
@@ -114,6 +114,7 @@ public class AffiliationMapper {
 
         return ClubMemberResponseDto.of(
                 affiliation.getAffiliationId(),
+                affiliation.getMember().getMemberId(),
                 affiliation.getPlayerName(),
                 affiliation.getBackNumber()
         );


### PR DESCRIPTION
## 🧩 작업 배경

선수 기록을 회원가입 이후 실제 멤버 데이터로 이관할 수 있는 API가 필요했습니다.

초기 설계에서는
*	멤버 단위로 기록 이관이 가능하도록 구현하려 했으나
*	이 방식은 가입 요청 승인 시 생성되는 Affiliation과의 관계가 모호하고,
*	승인 대상 멤버의 데이터가 기존 Affiliation에 직접 연결되지 않는 구조적 한계가 있었습니다.

이에 따라,
👉 클럽 가입 요청을 승인하는 시점에만 선수 기록을 이관하는 방식으로 설계를 수정했습니다.

## ✨ 주요 변경 사항

1️⃣ 선수 기록 이관 API 추가 (메인 기능)
* 	회원가입 이전에 생성된 선수 기록을
👉 가입 요청이 승인된 멤버의 기존 Affiliation 객체로 이관
*	새로운 Affiliation을 생성하지 않고
기존 Affiliation의 값을 갱신하는 방식으로 이관
*	가입 승인이라는 도메인 이벤트를 기준으로 이관 책임을 명확히 분리

2️⃣ 이관 방식 변경: 멤버 단위 → 가입 승인 단위
*	초기 설계: 멤버 기준으로 기록 이관
*	변경 설계: 가입 요청 승인 시점에만 기록 이관
*	승인되는 멤버의 선수 데이터(Affiliation)가
    *	👉 별도의 새로운 Affiliation으로 생성되지 않고
    *	👉 기존 승인 대상 Affiliation에 안전하게 이관 가능

3️⃣ 이관 안정성 확보를 위한 검증 로직 추가
*	이미 Member가 매핑된 Affiliation에 대해서는 이관 불가
*	중복 이관 및 소유권 충돌 방지
*	데이터 정합성 강화

4️⃣ 부가 수정 사항 (이관 API 지원 목적)
*	클럽 멤버 / 가입 요청 조회 DTO에 memberId 필드 추가
*	가입 승인 흐름에서 이관 대상 식별을 위한 최소한의 구조 보완

## 🎯 설계 의도 요약
	•	선수 기록이관 API 추가
	•	가입 승인 이전&이후 이관은 불가능
	•	가입 승인 시점에만 기존 Affiliation 데이터를 활용하여 이관
	•	도메인 흐름(가입 요청 → 승인 → 기록 이관)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new endpoints that mutate affiliation/member relationships and delete records; mistakes could cause incorrect membership mapping or data loss despite added validation and permission checks.
> 
> **Overview**
> Adds two club management APIs: `GET /clubs/{club_id}/members` to list club members (new `ClubMembersListResponseDto`) and `POST /clubs/{club_id}/players/transfers` to transfer a player’s affiliation record to a target `memberId`.
> 
> Implements transfer logic in `ClubService.transferPlayerRecord` with management-role authorization, new repository queries, and new validation errors (`PLAYER_HAS_MEMBER_ID`, `NOT_FOUND_SOURCE_PLAYER`, `NOT_FOUND_PLAYER_TO_CLUB`); the transfer updates the source `Affiliation`’s `playerName`/`member` and deletes the target affiliation record.
> 
> Extends join-request responses to include `memberId`, and updates batch goal inserts to populate `created_at`/`updated_at` timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf60f1440b00ae7aca2a14961c9fac2d29d33dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->